### PR TITLE
DS-1671: Sort of faux stream bulk download script.

### DIFF
--- a/CMR/Output.py
+++ b/CMR/Output.py
@@ -36,10 +36,11 @@ def cmr_to_csv(rgen):
     for l in template.stream(results=rgen()):
         yield l
 
-def cmr_to_download(rlist):
+def cmr_to_download(rgen):
     logging.debug('translating: bulk download script')
-    bd_res = requests.post(get_config()['bulk_download_api'], data={'products': ','.join([p['downloadUrl'] for p in rlist])})
-    return (bd_res.text)
+    plist = [p['downloadUrl'] for p in rgen()]
+    bd_res = requests.post(get_config()['bulk_download_api'], data={'products': ','.join(plist)})
+    yield (bd_res.text)
 
 def cmr_to_kml(rgen):
     logging.debug('translating: kml')


### PR DESCRIPTION
This is not REALLY streaming it, but it is a lighter-weight handling of the results and is compatible with the expected streaming framework. To actually stream a bulk download script, we would need to update the BD service as well.