### PR TITLE
Better handling of zero results in json output.

### DIFF
--- a/CMR/Query.py
+++ b/CMR/Query.py
@@ -85,5 +85,5 @@ class CMRQuery:
                     logging.debug('Max results reached, terminating')
                     return
             if self.result_counter == 0:
-                yield []
+                yield None
             logging.debug('End of available results reached')


### PR DESCRIPTION
josh's iterencode did not like a 0-length iterator claiming its length was 1 (but we can't know if the length is >0 beforehand!) which was causing it to buffer its output, but then never output the opening [ on the empty array since it would just quit out of the encode when it got to the end of the 0-length iter. This resulted in invalid json!

I found a developer discussion on this, and their eventual stance was "We don't want to consider scenarios where you don't know the length ahead of time (even though it's super common), so this is not a bug", even though the same approach apparently worked fine for outputting to a file.

SO, run the generator as many times as needed during the faux-iterator's __init__ method, until we find the first not-None item. Stash that item for actual output, and set the alleged length of the iterator to something >0. Doesn't matter what, just can't be 0. If we don't get any actual results, report the length as 0, which causes iterencode to properly output its encoded json buffer.

Also, re-organized the actual json object building approach to support this stashed-first-item approach. Separated that action from actually building the json object for each product into getItem. So now when subclassing any new json-based output, one need only consider getItem for generating each specific product.

OOF.