### PR TITLE
Use page size if no max results was given

### DIFF
--- a/APIProxy.py
+++ b/APIProxy.py
@@ -36,8 +36,12 @@ class APIProxyQuery:
             try:
                 logging.debug('Handling query from {0}'.format(self.request.access_route[-1]))
                 maxResults = self.max_results
+
                 if self.output == 'jsonlite':
-                    maxResults = min(self.max_results, self.page_size)
+                    maxResults = min(maxResults, self.page_size) \
+                        if maxResults is not None \
+                        else self.page_size
+
                 q = CMRQuery(params=dict(self.cmr_params), output=self.output, max_results=maxResults, analytics=True)
                 if(self.output == 'count'):
                     return(make_response(str(q.get_count())))


### PR DESCRIPTION
`min(maxResults, self.page_size)` was throwing when `maxResults` was set to `None` (which is the default).