### PR TITLE
List of fixes in first comment

### DIFF
--- a/SearchAPI/SearchQuery.py
+++ b/SearchAPI/SearchQuery.py
@@ -62,6 +62,15 @@ class APISearchQuery:
                 'No searchable parameters specified, queries must include'
                 ' parameters besides output= and maxresults='
             )
+        if 'granule_list' in searchables and len(searchables) > 1:
+            raise ValueError(
+                'granule_list may not be used in conjunction with other search parameters'
+            )
+
+        if 'product_list' in searchables and len(searchables) > 1:
+            raise ValueError(
+                'product_list may not be used in conjunction with other search parameters'
+            )
 
     def check_and_set_cmr_params(self):
         self.cmr_params, self.output, self.max_results = \

--- a/SearchAPI/endpoints.py
+++ b/SearchAPI/endpoints.py
@@ -19,7 +19,6 @@ class FilesToWKT_Endpoint:
 
 
     def get_response(self):
-        d = api_headers.base(mimetype='application/json')
         resp_dict = self.make_response()
         ###### For backwards compatibility #################################
         if "parsed wkt" in resp_dict:                                      #
@@ -27,7 +26,7 @@ class FilesToWKT_Endpoint:
             for key, val in repaired_json.items():                         #
                 resp_dict[key] = val                                       #
         ####################################################################
-        return Response(json.dumps(resp_dict, sort_keys=True, indent=4), 200, headers=d)
+        return Response(json.dumps(resp_dict, sort_keys=True, indent=4), 200, mimetype='application/json')
 
     def make_response(self):
         if self.files == []:
@@ -44,9 +43,8 @@ class RepairWKT_Endpoint:
             self.wkt = None
 
     def get_response(self):
-        d = api_headers.base(mimetype='application/json')
         resp_dict = self.make_response()
-        return Response(json.dumps(resp_dict, sort_keys=True, indent=4), 200, headers=d)
+        return Response(json.dumps(resp_dict, sort_keys=True, indent=4), 200, mimetype='application/json')
 
     def make_response(self):
         if self.wkt == None:
@@ -64,9 +62,8 @@ class DateValidator_Endpoint:
             self.date = None
 
     def get_response(self):
-        d = api_headers.base(mimetype='application/json')
         resp_dict = self.make_response()
-        return Response(json.dumps(resp_dict, sort_keys=True, indent=4), 200, headers=d)
+        return Response(json.dumps(resp_dict, sort_keys=True, indent=4), 200, mimetype='application/json')
 
     def make_response(self):
         if self.date == None:
@@ -88,9 +85,8 @@ class MissionList_Endpoint:
             self.platform = None
 
     def get_response(self):
-        d = api_headers.base(mimetype='application/json')
         resp_dict = self.make_response()
-        return Response(json.dumps(resp_dict, sort_keys=True, indent=4), 200, headers=d)
+        return Response(json.dumps(resp_dict, sort_keys=True, indent=4), 200, mimetype='application/json')
 
     def make_response(self):
         # Setup data for request.

--- a/SearchAPI/maturities.yml
+++ b/SearchAPI/maturities.yml
@@ -17,7 +17,7 @@ default:
 local:
     bulk_download_api: https://bulk-download.asf.alaska.edu
     analytics_id: None
-    this_api: http://127.0.0.1:5000
+    this_api: http://127.0.0.1
     cmr_base: https://cmr.uat.earthdata.nasa.gov
     cmr_health: /search/health
     cmr_api: /search/granules.echo10

--- a/build/sam-deployment.yml
+++ b/build/sam-deployment.yml
@@ -38,7 +38,7 @@ phases:
       ## Pull both the base, and the image before this one, to use cached layers where possible.
       ## Can't get this working yet. Need to wipe ALL local images, and test if this works like I think it should.
       ## NOTE: Tested you do need to pull the base image FIRST, so sam can check if THAT needs updating.
-      # - docker pull public.ecr.aws/lambda/python:3.9
+      - docker pull public.ecr.aws/lambda/python:3.9
       # - docker pull "${PRIVATE_REPOSITORY_URI}:latest" && docker tag "${PRIVATE_REPOSITORY_URI}:latest" "searchapifunction:sam_image" || true
 
       ## Inject the github hash to version file, so you can check if deployed on the health endpoint.
@@ -78,3 +78,6 @@ phases:
 artifacts:
   files:
     - '**/*'
+cache:
+  paths:
+    -'.aws-sam/**/*'

--- a/build/sam-deployment.yml
+++ b/build/sam-deployment.yml
@@ -52,7 +52,7 @@ phases:
 
   build:
     commands:
-      - yum upgrade -y
+      - yum upgrade -y --skip-broken
       - sam build
 
       ## Make sure "latest" tag gets updated too. `sam deploy` only pushes a image with a weird hash, so each one is unique.

--- a/build/sam-deployment.yml
+++ b/build/sam-deployment.yml
@@ -52,7 +52,7 @@ phases:
 
   build:
     commands:
-      # - yum upgrade -y
+      - yum upgrade -y
       - sam build
 
       ## Make sure "latest" tag gets updated too. `sam deploy` only pushes a image with a weird hash, so each one is unique.

--- a/build/sam-deployment.yml
+++ b/build/sam-deployment.yml
@@ -53,7 +53,7 @@ phases:
   build:
     commands:
       # - yum upgrade -y
-      - sam build
+      - sam build --base-dir ${CODEBUILD_SRC_DIR}
 
       ## Make sure "latest" tag gets updated too. `sam deploy` only pushes a image with a weird hash, so each one is unique.
       - docker tag "searchapifunction:sam_image" "${PRIVATE_REPOSITORY_URI}:latest" && docker push "${PRIVATE_REPOSITORY_URI}:latest"

--- a/build/sam-deployment.yml
+++ b/build/sam-deployment.yml
@@ -15,7 +15,7 @@ phases:
   pre_build:
     commands:
       ## Seeing if cache even exists:
-      - ls -halt .aws-sam
+      - ls -halt /var/lib/docker
 
       ## Errors:
       - if [[ -z "${Image}" ]]; then echo "ERROR - must declare 'Image' where using codebuild! (What repo inside ECR to push to.). Quitting"; exit -1; fi
@@ -39,9 +39,9 @@ phases:
       - PRIVATE_REPOSITORY_URI="$(aws sts get-caller-identity --query Account --output text).dkr.ecr.${AWS_REGION}.amazonaws.com/${Image}"
 
       ## Pull both the base, and the image before this one, to use cached layers where possible.
-      ## Can't get this working yet. Need to wipe ALL local images, and test if this works like I think it should.
+      ## Can't get this working yet. AWS only supports caching docker layers "locally". There's workarounds for vanilla docker containers, but nothing sam-related.
       ## NOTE: Tested you do need to pull the base image FIRST, so sam can check if THAT needs updating.
-      - docker pull public.ecr.aws/lambda/python:3.9
+      # - docker pull public.ecr.aws/lambda/python:3.9
       # - docker pull "${PRIVATE_REPOSITORY_URI}:latest" && docker tag "${PRIVATE_REPOSITORY_URI}:latest" "searchapifunction:sam_image" || true
 
       ## Inject the github hash to version file, so you can check if deployed on the health endpoint.
@@ -53,7 +53,7 @@ phases:
   build:
     commands:
       # - yum upgrade -y
-      - sam build --base-dir ${CODEBUILD_SRC_DIR}
+      - sam build
 
       ## Make sure "latest" tag gets updated too. `sam deploy` only pushes a image with a weird hash, so each one is unique.
       - docker tag "searchapifunction:sam_image" "${PRIVATE_REPOSITORY_URI}:latest" && docker push "${PRIVATE_REPOSITORY_URI}:latest"
@@ -87,6 +87,6 @@ artifacts:
   files:
     - '**/*'
 
-cache:
-  paths:
-    - '.aws-sam/**/*'
+# cache:
+#   paths:
+#     - '.aws-sam/**/*'

--- a/build/sam-deployment.yml
+++ b/build/sam-deployment.yml
@@ -14,6 +14,9 @@ phases:
 
   pre_build:
     commands:
+      ## Seeing if cache even exists:
+      - ls -halt .aws-sam
+
       ## Errors:
       - if [[ -z "${Image}" ]]; then echo "ERROR - must declare 'Image' where using codebuild! (What repo inside ECR to push to.). Quitting"; exit -1; fi
       - if [[ -z "${Maturity}" ]]; then echo "ERROR - must declare 'Maturity' when using codebuild! (Check 'SearchAPI/maturities.yml' for available options.). Quitting"; exit -1; fi
@@ -75,7 +78,7 @@ phases:
       - if [[ -n ${TestSuiteURL} ]]; then pytest -r -n auto --df known_bugs ${EXTRA_PYTEST_ARGS} . --api ${TestSuiteURL}; fi
         # -r = show warnings
         # -n = how many threads (auto = all on system)
-      
+
       - echo "PATH:" && pwd
       - file .aws-sam
       - ls -halt .aws-sam

--- a/build/sam-deployment.yml
+++ b/build/sam-deployment.yml
@@ -75,9 +75,15 @@ phases:
       - if [[ -n ${TestSuiteURL} ]]; then pytest -r -n auto --df known_bugs ${EXTRA_PYTEST_ARGS} . --api ${TestSuiteURL}; fi
         # -r = show warnings
         # -n = how many threads (auto = all on system)
+      
+      - echo "PATH:" && pwd
+      - file .aws-sam
+      - ls -halt .aws-sam
+
 artifacts:
   files:
     - '**/*'
+
 cache:
   paths:
-    -'.aws-sam/**/*'
+    - '.aws-sam/**/*'

--- a/build/sam-deployment.yml
+++ b/build/sam-deployment.yml
@@ -79,10 +79,6 @@ phases:
         # -r = show warnings
         # -n = how many threads (auto = all on system)
 
-      - echo "PATH:" && pwd
-      - file .aws-sam
-      - ls -halt .aws-sam
-
 artifacts:
   files:
     - '**/*'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ argcomplete==1.12.3
 asn1crypto==1.4.0
 atomicwrites==1.4.0
 attrs==21.2.0
-aws-wsgi==0.2.7
 backports.zoneinfo==0.2.1
 boto3==1.19.0
 botocore==1.22.0
@@ -91,6 +90,7 @@ requests-toolbelt==0.9.1
 s3transfer==0.5.0
 scandir==1.10.0
 scikit-learn==1.0.1                  # WARNING: 0.24.1 breaks ShorelineMask26 test
+serverless-wsgi==3.0.0
 Shapely==1.7.1
 six==1.16.0
 smmap==4.0.0

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setuptools.setup(
     long_description=readme,
     url="https://github.com/asfadmin/Discovery-SearchAPI.git",
     packages=setuptools.find_packages(),
-    package_dir={"SearchAPI": "SearchAPI"},   
+    package_dir={"SearchAPI": "SearchAPI"},
+    package_data={"SearchAPI": ["*.yml", "*.yaml"]},
 )

--- a/yml_tests/test_Baseline.yml
+++ b/yml_tests/test_Baseline.yml
@@ -127,6 +127,7 @@ tests:
     expected code: 200
 
 - baseline don't allow master keyword:
+    reference: ""
     master: S1B_IW_SLC__1SDV_20190610T143518_20190610T143545_016635_01F4F7_6EA1
     output: csv
 


### PR DESCRIPTION
- put header into Response object directly, improving responses when under load
- Added granule_list/product_list fix, for only being able to use one (Already on prod)
- switched from aws_wsgi to serverless_wsgi
- Added inclusion of yml files into package, so that maturities.yml exists