### PR TITLE
Replaces depecrated cmr-scroll-session header with cmr-search-after (DS-4119)

### DIFF
--- a/SearchAPI/CMR/Query.py
+++ b/SearchAPI/CMR/Query.py
@@ -31,9 +31,6 @@ class CMRQuery:
             {'options[platform][ignore_case]': 'true'}
         ]
 
-        if cfg['cmr_scroll']:
-            self.extra_params.append({'scroll': 'true'}) # Just leave this off if false, for the sake of the CMR team looking at logs
-
         self.result_counter = 0
 
         time_in_seconds = 14.5 * 60

--- a/SearchAPI/CMR/SubQuery.py
+++ b/SearchAPI/CMR/SubQuery.py
@@ -123,7 +123,7 @@ class CMRSubQuery:
         self.hits = int(response.headers['CMR-hits'])
         self.cmr_search_after = None
 
-        if self.scroll:            
+        if self.scroll and 'CMR-Search-After' in response.headers:            
             self.cmr_search_after = response.headers['CMR-Search-After']
             request.cmr_search_after.append(self.cmr_search_after)
 

--- a/SearchAPI/CMR/SubQuery.py
+++ b/SearchAPI/CMR/SubQuery.py
@@ -125,7 +125,6 @@ class CMRSubQuery:
 
         if self.scroll and 'CMR-Search-After' in response.headers:            
             self.cmr_search_after = response.headers['CMR-Search-After']
-            request.cmr_search_after.append(self.cmr_search_after)
 
         # logging.debug(f'CMR reported {self.hits} hits for session {self.cmr_search_after}')
         logging.debug('Parsing page 1')
@@ -149,7 +148,6 @@ class CMRSubQuery:
 
             if self.scroll and 'CMR-Search-After' in response.headers:
                 self.cmr_search_after = response.headers['CMR-Search-After']
-                request.cmr_search_after.append(self.cmr_search_after)
                 session.headers.update({'CMR-Search-After': self.cmr_search_after})
                 
             logging.debug(f'Parsing page {page_num}')

--- a/SearchAPI/CMR/SubQuery.py
+++ b/SearchAPI/CMR/SubQuery.py
@@ -117,7 +117,6 @@ class CMRSubQuery:
 
         self.hits = int(response.headers['CMR-hits'])
 
-        # logging.debug(f'CMR reported {self.hits} hits for session {self.cmr_search_after}')
         logging.debug('Parsing page 1')
 
         for p in parse_cmr_response(response, self.req_fields):

--- a/SearchAPI/application.py
+++ b/SearchAPI/application.py
@@ -116,7 +116,6 @@ def handle_oversize_request(error):
 def preflight():
     load_config()
     analytics_pageview()
-    request.cmr_search_after = []
     logging.debug('Using config:')
     logging.debug(get_config())
     request.query_start_time = perf_counter()

--- a/SearchAPI/application.py
+++ b/SearchAPI/application.py
@@ -14,8 +14,6 @@ import json
 from SearchAPI.CMR.Health import get_cmr_health
 from SearchAPI.Analytics import analytics_pageview
 from werkzeug.exceptions import RequestEntityTooLarge
-import multiprocessing
-import requests
 from SearchAPI.asf_env import get_config, load_config
 from time import perf_counter
 import boto3

--- a/SearchAPI/application.py
+++ b/SearchAPI/application.py
@@ -116,7 +116,7 @@ def handle_oversize_request(error):
 def preflight():
     load_config()
     analytics_pageview()
-    request.cmr_scroll_sessions = []
+    request.cmr_search_after = []
     logging.debug('Using config:')
     logging.debug(get_config())
     request.query_start_time = perf_counter()
@@ -124,17 +124,6 @@ def preflight():
 # Post-flight operations
 @application.teardown_request
 def postflight(e):
-    def close_cmr_scroll(req):
-        try:
-            logging.debug(f'Closing CMR scroll session {req["sid"]}')
-            r = requests.post(req['url'], json={'scroll_id': req['sid']})
-            if r.ok:
-                logging.debug(f'Closed session {req["sid"]}')
-            else:
-                logging.warning(f'CMR returned HTTP {r.status_code} when closing scroll session {req["sid"]}')
-        except Exception as e:
-            logging.warning(f'Failed to close scroll session {req["sid"]}: {e}')
-
     try:
         query_run_time = perf_counter() - request.query_start_time
         logging.debug(f'Total query run time: {query_run_time}')
@@ -157,15 +146,6 @@ def postflight(e):
                 ],
                 Namespace = 'SearchAPI'
             )
-
-        logging.debug(f'Closing {len(request.cmr_scroll_sessions)} scroll sessions')
-        if len(request.cmr_scroll_sessions) > 0:
-            num_processes = min([4, len(request.cmr_scroll_sessions)])
-            p = multiprocessing.pool.ThreadPool(processes=num_processes)
-            reqs = [{'sid': sid, 'url': get_config()['cmr_base']+get_config()['cmr_clear_scroll']} for sid in request.cmr_scroll_sessions]
-            p.map_async(close_cmr_scroll, reqs)
-            p.close()
-            p.join()
     except Exception as e:
         logging.critical(f'Failure during request teardown: {e}')
 

--- a/SearchAPI/asf_env.py
+++ b/SearchAPI/asf_env.py
@@ -33,17 +33,6 @@ def load_config():
                 request.cmr_provider = request.local_values['cmr_provider']
                 del request.local_values['cmr_provider']
 
-    # dynamically switch to non-scrolled results if the max results <= page size
-    if 'maxresults' in request.local_values:
-        try:
-            if int(request.local_values['maxresults']) <= config['cmr_page_size']:
-                config['cmr_scroll'] = False
-        except ValueError:
-            pass
-
-    if 'granule_list' in request.local_values or 'product_list' in request.local_values:
-        config['cmr_scroll'] = False
-
     request.asf_config = config
     request.asf_base_maturity = maturity
 

--- a/SearchAPI/maturities.yml
+++ b/SearchAPI/maturities.yml
@@ -6,8 +6,6 @@ default:
     cmr_health: /search/health
     cmr_api: /search/granules.echo10
     cmr_collections: /search/collections
-    cmr_clear_scroll: /search/clear-scroll
-    cmr_scroll: True
     cmr_page_size: 250
     cmr_headers:
         Client-Id: local_searchapi_asf
@@ -22,8 +20,6 @@ local:
     cmr_health: /search/health
     cmr_api: /search/granules.echo10
     cmr_collections: /search/collections
-    cmr_clear_scroll: /search/clear-scroll
-    cmr_scroll: True
     cmr_page_size: 250
     cmr_headers:
         Client-Id: local_searchapi_asf
@@ -38,8 +34,6 @@ devel:
     cmr_health: /search/health
     cmr_api: /search/granules.echo10
     cmr_collections: /search/collections
-    cmr_clear_scroll: /search/clear-scroll
-    cmr_scroll: False
     cmr_page_size: 1000
     cmr_headers:
         Client-Id: devel_vertex_asf
@@ -54,8 +48,6 @@ devel-beanstalk:
     cmr_health: /search/health
     cmr_api: /search/granules.echo10
     cmr_collections: /search/collections
-    cmr_clear_scroll: /search/clear-scroll
-    cmr_scroll: True
     cmr_page_size: 250
     cmr_headers:
         Client-Id: devel_searchapi_asf
@@ -70,8 +62,6 @@ test:
     cmr_health: /search/health
     cmr_api: /search/granules.echo10
     cmr_collections: /search/collections
-    cmr_clear_scroll: /search/clear-scroll
-    cmr_scroll: False
     cmr_page_size: 1000
     cmr_headers:
         Client-Id: test_vertex_asf
@@ -86,8 +76,6 @@ test-beanstalk:
     cmr_health: /search/health
     cmr_api: /search/granules.echo10
     cmr_collections: /search/collections
-    cmr_clear_scroll: /search/clear-scroll
-    cmr_scroll: True
     cmr_page_size: 250
     cmr_headers:
         Client-Id: test_searchapi_asf
@@ -102,8 +90,6 @@ prod:
     cmr_health: /search/health
     cmr_api: /search/granules.echo10
     cmr_collections: /search/collections
-    cmr_clear_scroll: /search/clear-scroll
-    cmr_scroll: True
     cmr_page_size: 250
     cmr_headers:
         Client-Id: searchapi_asf
@@ -118,8 +104,6 @@ prod-private:
     cmr_health: /search/health
     cmr_api: /search/granules.echo10
     cmr_collections: /search/collections
-    cmr_clear_scroll: /search/clear-scroll
-    cmr_scroll: False
     cmr_page_size: 1000
     cmr_headers:
         Client-Id: vertex_asf


### PR DESCRIPTION
- Deprecated CMR-Scroll-Session header replaced by CMR-Search-After (https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#search-after)
- Removes now unused postflight scroll session logic (no longer required with CMR-Search-After)