### PR TITLE
New asf_search Geojson-based Output Format

### DIFF
--- a/SearchAPI/CMR/Output/asf_search.py
+++ b/SearchAPI/CMR/Output/asf_search.py
@@ -2,7 +2,7 @@ import logging
 import json
 from .json import JSONStreamArray
 
-def req_fields_geojson():
+def req_fields_asf_search():
     fields = [
         'beamModeType',
         'browse',
@@ -32,19 +32,20 @@ def req_fields_geojson():
         'startTime',
         'stopTime',
         'downloadUrl',
+        'canInsar',
     ]
     return fields
 
-def cmr_to_geojson(rgen, includeBaseline=False, addendum=None):
-    logging.debug('translating: geojson')
+def cmr_to_asf_search(rgen, includeBaseline=False, addendum=None):
+    logging.debug('translating: asf_search')
 
-    streamer = GeoJSONStreamArray(rgen, includeBaseline)
+    streamer = ASFSearchStreamArray(rgen, includeBaseline)
 
     for p in json.JSONEncoder(indent=2, sort_keys=True).iterencode({'type': 'FeatureCollection','features':streamer}):
         yield p
 
 
-class GeoJSONStreamArray(JSONStreamArray):
+class ASFSearchStreamArray(JSONStreamArray):
 
     def getItem(self, p):
         for i in p.keys():
@@ -94,6 +95,7 @@ class GeoJSONStreamArray(JSONStreamArray):
                 'startTime': p['startTime'],
                 'stopTime': p['stopTime'],
                 'url': p['downloadUrl'],
+                'baseline': p.pop('baseline', None),
             }
         }
         if self.includeBaseline:

--- a/SearchAPI/CMR/Output/asf_search.py
+++ b/SearchAPI/CMR/Output/asf_search.py
@@ -36,7 +36,7 @@ def req_fields_asf_search():
     ]
     return fields
 
-def cmr_to_asf_search(rgen, includeBaseline=False):
+def cmr_to_asf_search(rgen, includeBaseline=False, addendum=None):
     logging.debug('translating: asf_search')
 
     streamer = ASFSearchStreamArray(rgen, includeBaseline)

--- a/SearchAPI/CMR/Output/asf_search.py
+++ b/SearchAPI/CMR/Output/asf_search.py
@@ -96,10 +96,9 @@ class ASFSearchStreamArray(JSONStreamArray):
                 'stopTime': p['stopTime'],
                 'url': p['downloadUrl'],
                 'baseline': p.pop('baseline', None),
+                'temporalBaseline': p.pop('temporalBaseline', None),
+                'perpendicularBaseline': p.pop('perpendicularBaseline', None)
             }
         }
-        if self.includeBaseline:
-            result['properties']['temporalBaseline'] = p['temporalBaseline']
-            result['properties']['perpendicularBaseline'] = p['perpendicularBaseline']
 
         return result

--- a/SearchAPI/CMR/Output/asf_search.py
+++ b/SearchAPI/CMR/Output/asf_search.py
@@ -36,7 +36,7 @@ def req_fields_asf_search():
     ]
     return fields
 
-def cmr_to_asf_search(rgen, includeBaseline=False, addendum=None):
+def cmr_to_asf_search(rgen, includeBaseline=False):
     logging.debug('translating: asf_search')
 
     streamer = ASFSearchStreamArray(rgen, includeBaseline)

--- a/SearchAPI/CMR/Output/geojson.py
+++ b/SearchAPI/CMR/Output/geojson.py
@@ -32,7 +32,6 @@ def req_fields_geojson():
         'startTime',
         'stopTime',
         'downloadUrl',
-        'stateVectors',
         'canInsar',
     ]
     return fields

--- a/SearchAPI/CMR/Output/geojson.py
+++ b/SearchAPI/CMR/Output/geojson.py
@@ -32,7 +32,8 @@ def req_fields_geojson():
         'startTime',
         'stopTime',
         'downloadUrl',
-        'stateVectors'
+        'stateVectors',
+        'canInsar',
     ]
     return fields
 
@@ -95,29 +96,11 @@ class GeoJSONStreamArray(JSONStreamArray):
                 'startTime': p['startTime'],
                 'stopTime': p['stopTime'],
                 'url': p['downloadUrl'],
-                'baseline': {
-                    'stateVectors': {
-                        'positions': {
-                            'prePosition': p['sv_pos_pre'],
-                            'postPosition': p['sv_pos_post'],
-                            'prePositionTime': p['sv_t_pos_pre'],
-                            'postPositionTime': p['sv_t_pos_post']
-                        },
-                        'velocities': {
-                            'preVelocity': p['sv_vel_pre'],
-                            'postVelocity': p['sv_vel_post'],
-                            'preVelocityTime': p['sv_t_vel_pre'],
-                            'postVelocityTime': p['sv_t_vel_post']
-                        }
-                    }
-                    
-                },
-                # 'temporalBaseline': p.pop('temporalBaseline'),
-                # 'perpendicularBaseline': p.pop('perpendicularBaseline')
+                'baseline': p.pop('baseline', None),
             }
         }
-        # if self.includeBaseline:
-        # result['properties']['temporalBaseline'] = p.pop('temporalBaseline')
-        # result['properties']['perpendicularBaseline'] = p.pop('perpendicularBaseline')
+        if self.includeBaseline:
+            result['properties']['temporalBaseline'] = p['temporalBaseline']
+            result['properties']['perpendicularBaseline'] = p['perpendicularBaseline']
 
         return result

--- a/SearchAPI/CMR/Output/geojson.py
+++ b/SearchAPI/CMR/Output/geojson.py
@@ -31,7 +31,8 @@ def req_fields_geojson():
         'shape',
         'startTime',
         'stopTime',
-        'downloadUrl'
+        'downloadUrl',
+        'stateVectors'
     ]
     return fields
 
@@ -93,11 +94,30 @@ class GeoJSONStreamArray(JSONStreamArray):
                 'sensor': p['sensor'],
                 'startTime': p['startTime'],
                 'stopTime': p['stopTime'],
-                'url': p['downloadUrl']
+                'url': p['downloadUrl'],
+                'baseline': {
+                    'stateVectors': {
+                        'positions': {
+                            'prePosition': p['sv_pos_pre'],
+                            'postPosition': p['sv_pos_post'],
+                            'prePositionTime': p['sv_t_pos_pre'],
+                            'postPositionTime': p['sv_t_pos_post']
+                        },
+                        'velocities': {
+                            'preVelocity': p['sv_vel_pre'],
+                            'postVelocity': p['sv_vel_post'],
+                            'preVelocityTime': p['sv_t_vel_pre'],
+                            'postVelocityTime': p['sv_t_vel_post']
+                        }
+                    }
+                    
+                },
+                # 'temporalBaseline': p.pop('temporalBaseline'),
+                # 'perpendicularBaseline': p.pop('perpendicularBaseline')
             }
         }
-        if self.includeBaseline:
-            result['properties']['temporalBaseline'] = p['temporalBaseline']
-            result['properties']['perpendicularBaseline'] = p['perpendicularBaseline']
+        # if self.includeBaseline:
+        # result['properties']['temporalBaseline'] = p.pop('temporalBaseline')
+        # result['properties']['perpendicularBaseline'] = p.pop('perpendicularBaseline')
 
         return result

--- a/SearchAPI/CMR/Output/geojson.py
+++ b/SearchAPI/CMR/Output/geojson.py
@@ -33,6 +33,7 @@ def req_fields_geojson():
         'stopTime',
         'downloadUrl',
         'canInsar',
+        'ascendingNodeTime'
     ]
     return fields
 

--- a/SearchAPI/CMR/Output/output_translators.py
+++ b/SearchAPI/CMR/Output/output_translators.py
@@ -1,4 +1,4 @@
-from SearchAPI.CMR.Output.asf_search import cmr_to_asf_search, req_fields_asf_search
+from .asf_search import cmr_to_asf_search, req_fields_asf_search
 from .count import count, req_fields_count
 from .csv import cmr_to_csv, req_fields_csv
 from .download import cmr_to_download, req_fields_download

--- a/SearchAPI/CMR/Output/output_translators.py
+++ b/SearchAPI/CMR/Output/output_translators.py
@@ -1,3 +1,4 @@
+from SearchAPI.CMR.Output.asf_search import cmr_to_asf_search, req_fields_asf_search
 from .count import count, req_fields_count
 from .csv import cmr_to_csv, req_fields_csv
 from .download import cmr_to_download, req_fields_download
@@ -18,5 +19,6 @@ def output_translators():
         'jsonlite':     [cmr_to_jsonlite, 'application/json; charset=utf-8', 'json', req_fields_jsonlite()],
         'jsonlite2':    [cmr_to_jsonlite2, 'application/json; charset=utf-8', 'json', req_fields_jsonlite2()],
         'kml':          [cmr_to_kml, 'application/vnd.google-earth.kml+xml; charset=utf-8', 'kmz', req_fields_kml()],
-        'metalink':     [cmr_to_metalink, 'application/metalink+xml; charset=utf-8', 'metalink', req_fields_metalink()]
+        'metalink':     [cmr_to_metalink, 'application/metalink+xml; charset=utf-8', 'metalink', req_fields_metalink()],
+        'asf_search':   [cmr_to_asf_search, 'application/geojson; charset=utf-8', 'geojson', req_fields_asf_search()]
     }

--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -128,7 +128,7 @@ def parse_granule(granule, req_fields):
             insarBaseline = get_val(field_paths['insarBaseline'])
             if insarBaseline is not None:
                 insarBaseline = float(insarBaseline)
-            result['baseline'] = {'perpendicularBaseline': insarBaseline} 
+            result['baseline'] = {'insarBaseline': insarBaseline} 
             remove_field('insarGrouping')
             if result['insarGrouping'] not in [None, 0, '0', 'NA', 'NULL']:
                 result['canInsar'] = True

--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -171,7 +171,8 @@ def parse_granule(granule, req_fields):
 
     # Parse any remaining needed fields from the CMR response
     multi_fields = [
-        'absoluteOrbit'
+        'absoluteOrbit',
+        'baseline'
     ]
     for field in req_fields:
         if field in multi_fields:

--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -119,7 +119,6 @@ def parse_granule(granule, req_fields):
                 },
             },
             'ascendingNodeTime': get_val(attr_path('ASC_NODE_TIME')),
-            'insarBaseline': None
         }
         remove_field('stateVectors')
 
@@ -131,9 +130,7 @@ def parse_granule(granule, req_fields):
             if insarBaseline is not None:
                 insarBaseline = float(insarBaseline)
             result['baseline'] = {
-                'insarBaseline': insarBaseline,
-                'stateVectors': None, 
-                'ascendingNodeTime': None
+                'insarBaseline': insarBaseline
                 } 
             remove_field('insarGrouping')
             if result['insarGrouping'] not in [None, 0, '0', 'NA', 'NULL']:

--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -103,11 +103,32 @@ def parse_granule(granule, req_fields):
         result['sv_pos_post'], result['sv_t_pos_post'] = parse_sv(get_val(attr_path('SV_POSITION_POST')))
         result['sv_vel_pre'],  result['sv_t_vel_pre']  = parse_sv(get_val(attr_path('SV_VELOCITY_PRE')))
         result['sv_vel_post'], result['sv_t_vel_post'] = parse_sv(get_val(attr_path('SV_VELOCITY_POST')))
+        result['baseline'] = {
+            'stateVectors': {
+                'positions': {
+                    'prePosition': result['sv_pos_pre'],
+                    'postPosition': result['sv_pos_post'],
+                    'prePositionTime': result['sv_t_pos_pre'],
+                    'postPositionTime': result['sv_t_pos_post']
+                },
+                'velocities': {
+                    'preVelocity': result['sv_vel_pre'],
+                    'postVelocity': result['sv_vel_post'],
+                    'preVelocityTime': result['sv_t_vel_pre'],
+                    'postVelocityTime': result['sv_t_vel_post']
+                }
+            }
+        }
         remove_field('stateVectors')
 
     if 'canInsar' in req_fields:
         if result['platform'] in ['ALOS', 'RADARSAT-1', 'JERS-1', 'ERS-1', 'ERS-2']:
             result['insarGrouping'] = get_val(field_paths['insarGrouping'])
+            
+            insarBaseline = get_val(field_paths['insarBaseline'])
+            if insarBaseline is not None:
+                insarBaseline = float(insarBaseline)
+            result['baseline'] = {'perpendicularBaseline': insarBaseline} 
             remove_field('insarGrouping')
             if result['insarGrouping'] not in [None, 0, '0', 'NA', 'NULL']:
                 result['canInsar'] = True

--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -116,7 +116,8 @@ def parse_granule(granule, req_fields):
                     'postVelocity': result['sv_vel_post'],
                     'preVelocityTime': result['sv_t_vel_pre'],
                     'postVelocityTime': result['sv_t_vel_post']
-                }
+                },
+                'ascendingNodeTime': get_val(attr_path('ASC_NODE_TIME'))
             }
         }
         remove_field('stateVectors')

--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -117,8 +117,9 @@ def parse_granule(granule, req_fields):
                     'preVelocityTime': result['sv_t_vel_pre'],
                     'postVelocityTime': result['sv_t_vel_post']
                 },
-                'ascendingNodeTime': get_val(attr_path('ASC_NODE_TIME'))
-            }
+            },
+            'ascendingNodeTime': get_val(attr_path('ASC_NODE_TIME')),
+            'insarBaseline': None
         }
         remove_field('stateVectors')
 
@@ -129,7 +130,11 @@ def parse_granule(granule, req_fields):
             insarBaseline = get_val(field_paths['insarBaseline'])
             if insarBaseline is not None:
                 insarBaseline = float(insarBaseline)
-            result['baseline'] = {'insarBaseline': insarBaseline} 
+            result['baseline'] = {
+                'insarBaseline': insarBaseline,
+                'stateVectors': None, 
+                'ascendingNodeTime': None
+                } 
             remove_field('insarGrouping')
             if result['insarGrouping'] not in [None, 0, '0', 'NA', 'NULL']:
                 result['canInsar'] = True

--- a/SearchAPI/SearchQuery.py
+++ b/SearchAPI/SearchQuery.py
@@ -148,7 +148,7 @@ def is_max_results_with_json_output(maxResults, output):
 
     return (
         maxResults is not None and
-        output.lower() in ['json', 'jsonlite', 'geojson', 'jsonlite2']
+        output.lower() in ['json', 'jsonlite', 'geojson', 'jsonlite2', 'asf_search']
     )
 
 

--- a/tools/api-prod-with-results-downloads.sh
+++ b/tools/api-prod-with-results-downloads.sh
@@ -141,10 +141,12 @@ wget -d -O API-PROD-maxResults-1-valid.CSV "https://api.daac.asf.alaska.edu/serv
 wget -d -O API-PROD-maxResults-1-valid.json "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=json"
 wget -d -O API-PROD-maxResults-1-valid.jsonlite "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=jsonlite"
 wget -d -O API-PROD-maxResults-1-valid.geojson "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=geojson"
+wget -d -O API-PROD-maxResults-1-valid.asf_search "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=asf_search"
 wget -d -O API-PROD-maxResults-2-valid.CSV "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=csv"
 wget -d -O API-PROD-maxResults-2-valid.json "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=json"
 wget -d -O API-PROD-maxResults-1-valid.jsonlite "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=jsonlite"
 wget -d -O API-PROD-maxResults-2-valid.geojson "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=geojson"
+wget -d -O API-PROD-maxResults-2-valid.asf_search "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=asf_search"
 
 # minBaselinPerp Keyword
 wget -d -O API-PROD-minBaselinePerp-150-10-valid.CSV "https://api.daac.asf.alaska.edu/services/search/param?minbaselineperp=150&platform=R1&maxresults=10&output=csv"
@@ -176,6 +178,7 @@ wget -d -O API-PROD-platform-SB-download-valid.py "https://api.daac.asf.alaska.e
 wget -d -O API-PROD-platform-SB-geojson-valid.geojson "https://api.daac.asf.alaska.edu/services/search/param?platform=SB&start=1+week+ago&end=now&maxresults=2000&output=geojson"
 wget -d -O API-PROD-platform-SB-json-valid.json "https://api.daac.asf.alaska.edu/services/search/param?platform=SB&start=1+week+ago&end=now&maxresults=2000&output=json"
 wget -d -O API-PROD-platform-SB-jsonlite-valid.jsonlite "https://api.daac.asf.alaska.edu/services/search/param?platform=SB&start=1+week+ago&end=now&maxresults=2000&output=jsonlite"
+wget -d -O API-PROD-platform-SB-asf_search-valid.asf_search "https://api.daac.asf.alaska.edu/services/search/param?platform=SB&start=1+week+ago&end=now&maxresults=2000&output=asf_search"
 wget -d -O API-PROD-platform-SB-kml-valid.kml "https://api.daac.asf.alaska.edu/services/search/param?platform=SB&start=1+week+ago&end=now&maxresults=2000&output=kml"
 wget -d -O API-PROD-platform-SB-metalink-valid.metalink "https://api.daac.asf.alaska.edu/services/search/param?platform=SB&start=1+week+ago&end=now&maxresults=2000&output=metalink"
 
@@ -387,6 +390,7 @@ wget -d -O API-PROD-bbox-incomplete-invalid.csv "https://api.daac.asf.alaska.edu
 wget -d -O API-PROD-bbox-incomplete-json-invalid.json "https://api.daac.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=JSON"
 wget -d -O API-PROD-bbox-incomplete-jsonlite-invalid.jsonlite "https://api.daac.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=JSONLITE"
 wget -d -O API-PROD-bbox-incomplete-geojson-invalid.geojson "https://api.daac.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=GEO.JSON"
+wget -d -O API-PROD-bbox-incomplete-asf_search-invalid.asf_search "https://api.daac.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=ASF_SEARCH"
 wget -d -O API-PROD-bbox-incomplete-download-invalid.py "https://api.daac.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1&output=download"
 
 # beamMode Keyword Invalid
@@ -481,14 +485,17 @@ wget -d -O API-PROD-maxResults-0-invalid.CSV "https://api.daac.asf.alaska.edu/se
 wget -d -O API-PROD-maxResults-0-invalid.json "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=json"
 wget -d -O API-PROD-maxResults-0-invalid.jsonlite "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=jsonlite"
 wget -d -O API-PROD-maxResults-0-invalid.geojson "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=geojson"
+wget -d -O API-PROD-maxResults-0-invalid.asf_search "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=asf_search"
 wget -d -O API-PROD-maxResults-a-invalid.CSV "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=csv"
 wget -d -O API-PROD-maxResults-a-invalid.json "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=json"
 wget -d -O API-PROD-maxResults-a-invalid.jsonlite "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=jsonlite"
 wget -d -O API-PROD-maxResults-a-invalid.geojson "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=geojson"
+wget -d -O API-PROD-maxResults-a-invalid.asf_search "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=asf_search"
 wget -d -O API-PROD-maxResults-%-invalid.CSV "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=csv"
 wget -d -O API-PROD-maxResults-%-invalid.json "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=json"
 wget -d -O API-PROD-maxResults-%-invalid.jsonlite "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=jsonlite"
 wget -d -O API-PROD-maxResults-%-invalid.geojson "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=geojson"
+wget -d -O API-PROD-maxResults-%-invalid.asf_search "https://api.daac.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=asf_search"
 
 # minBaselinPerp Keyword Invalid
 wget -d -O API-PROD-minBaselineperp-TEST-invalid.csv "https://api.daac.asf.alaska.edu/services/search/param?minbaselineperp=TEST&platform=R1&maxresults=10&output=csv"

--- a/tools/api-test-with-results-downloads.sh
+++ b/tools/api-test-with-results-downloads.sh
@@ -141,10 +141,12 @@ wget -d -O API-TEST-maxResults-1-valid.CSV "https://api-test.asf.alaska.edu/serv
 wget -d -O API-TEST-maxResults-1-valid.json "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=json"
 wget -d -O API-TEST-maxResults-1-valid.jsonlite "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=jsonlite"
 wget -d -O API-TEST-maxResults-1-valid.geojson "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=geojson"
+wget -d -O API-TEST-maxResults-1-valid.asf_search "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=asf_search"
 wget -d -O API-TEST-maxResults-2-valid.CSV "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=csv"
 wget -d -O API-TEST-maxResults-2-valid.json "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=json"
 wget -d -O API-TEST-maxResults-1-valid.jsonlite "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=jsonlite"
 wget -d -O API-TEST-maxResults-2-valid.geojson "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=geojson"
+wget -d -O API-TEST-maxResults-2-valid.asf_search "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=asf_search"
 
 # minBaselinPerp Keyword
 wget -d -O API-TEST-minBaselinePerp-150-10-valid.CSV "https://api-test.asf.alaska.edu/services/search/param?minbaselineperp=150&platform=R1&maxresults=10&output=csv"
@@ -174,6 +176,7 @@ wget -d -O API-TEST-platform-SB-valid.CSV "https://api-test.asf.alaska.edu/servi
 wget -d -O API-TEST-platform-SB-count-valid.CSV "https://api-test.asf.alaska.edu/services/search/param?platform=SB&maxresults=2000&output=count"
 wget -d -O API-TEST-platform-SB-download-valid.py "https://api-test.asf.alaska.edu/services/search/param?platform=SB&maxresults=2000&output=download"
 wget -d -O API-TEST-platform-SB-geojson-valid.geojson "https://api-test.asf.alaska.edu/services/search/param?platform=SB&maxresults=2000&output=geojson"
+wget -d -O API-TEST-platform-SB-asf_search-valid.asf_search "https://api-test.asf.alaska.edu/services/search/param?platform=SB&maxresults=2000&output=asf_search"
 wget -d -O API-TEST-platform-SB-json-valid.json "https://api-test.asf.alaska.edu/services/search/param?platform=SB&maxresults=2000&output=json"
 wget -d -O API-TEST-platform-SB-jsonlite-valid.jsonlite "https://api-test.asf.alaska.edu/services/search/param?platform=SB&maxresults=2000&output=jsonlite"
 wget -d -O API-TEST-platform-SB-kml-valid.kml "https://api-test.asf.alaska.edu/services/search/param?platform=SB&maxresults=2000&output=kml"
@@ -394,6 +397,7 @@ wget -d -O API-TEST-bbox-incomplete-invalid.csv "https://api-test.asf.alaska.edu
 wget -d -O API-TEST-bbox-incomplete-json-invalid.json "https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=JSON"
 wget -d -O API-TEST-bbox-incomplete-jsonlite-invalid.jsonlite "https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=JSONLITE"
 wget -d -O API-TEST-bbox-incomplete-geojson-invalid.geojson "https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=GEO.JSON"
+wget -d -O API-TEST-bbox-incomplete-asf_search-invalid.asf_search "https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=ASF_SEARCH"
 wget -d -O API-TEST-bbox-incomplete-download-invalid.py "https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1&output=download"
 
 # beamMode Keyword Invalid
@@ -488,14 +492,17 @@ wget -d -O API-TEST-maxResults-0-invalid.CSV "https://api-test.asf.alaska.edu/se
 wget -d -O API-TEST-maxResults-0-invalid.json "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=json"
 wget -d -O API-TEST-maxResults-0-invalid.jsonlite "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=jsonlite"
 wget -d -O API-TEST-maxResults-0-invalid.geojson "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=geojson"
+wget -d -O API-TEST-maxResults-0-invalid.asf_search "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=asf_search"
 wget -d -O API-TEST-maxResults-a-invalid.CSV "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=csv"
 wget -d -O API-TEST-maxResults-a-invalid.json "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=json"
 wget -d -O API-TEST-maxResults-a-invalid.jsonlite "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=jsonlite"
 wget -d -O API-TEST-maxResults-a-invalid.geojson "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=geojson"
+wget -d -O API-TEST-maxResults-a-invalid.asf_search "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=asf_search"
 wget -d -O API-TEST-maxResults-%-invalid.CSV "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=csv"
 wget -d -O API-TEST-maxResults-%-invalid.json "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=json"
 wget -d -O API-TEST-maxResults-%-invalid.jsonlite "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=jsonlite"
 wget -d -O API-TEST-maxResults-%-invalid.geojson "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=geojson"
+wget -d -O API-TEST-maxResults-%-invalid.asf_search "https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=asf_search"
 
 # minBaselinPerp Keyword Invalid
 wget -d -O API-TEST-minBaselineperp-TEST-invalid.csv "https://api-test.asf.alaska.edu/services/search/param?minbaselineperp=TEST&platform=R1&maxresults=10&output=csv"

--- a/tools/queries.txt
+++ b/tools/queries.txt
@@ -103,10 +103,12 @@ https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxres
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=json
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=jsonlite
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=geojson
+https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=1&output=asf_search
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=csv
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=json
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=jsonlite
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=geojson
+https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=2&output=asf_search
 
 # mindoppler + platform + MaxResults + CSV output
 https://api-test.asf.alaska.edu/services/search/param?mindoppler=-20000&platform=R1&maxresults=10&output=csv
@@ -323,11 +325,12 @@ https://api-test.asf.alaska.edu/services/search/param?asfframe=$&maxresults=10&o
 https://api-test.asf.alaska.edu/services/search/param?bbox=TEST&output=CSV
 https://api-test.asf.alaska.edu/services/search/param?bbox=$&output=CSV
 
-# bbox incomplete + CSV,JSON,JSONLITE,GEOJSON output
+# bbox incomplete + CSV,JSON,JSONLITE,GEOJSON, ASF_SEARCH output
 https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=CSV
 https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=JSON
 https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=JSONLITE
 https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=GEO.JSON
+https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1,65.5,0&output=ASF_SEARCH
 https://api-test.asf.alaska.edu/services/search/param?bbox=-150.2,65.0,-150.1&output=CSV
 
 # beamMode Invalid + CSV output
@@ -418,14 +421,17 @@ https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxres
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=json
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=jsonlite
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=geojson
+https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=0&output=asf_search
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=csv
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=json
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=jsonlite
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=geojson
+https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=a&output=asf_search
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=csv
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=json
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=jsonlite
 https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=geojson
+https://api-test.asf.alaska.edu/services/search/param?platform=SENTINEL-1&maxresults=%&output=asf_search
 
 # offNadirAngle Invalid + CSV output
 https://api-test.asf.alaska.edu/services/search/param?offNadirAngle=TEST&maxResults=1000&output=CSV

--- a/yml_tests/test_Baseline.yml
+++ b/yml_tests/test_Baseline.yml
@@ -119,6 +119,14 @@ tests:
     expected file: json
     expected code: 200
 
+- baseline asf_search:
+    reference: S1B_IW_SLC__1SDV_20180112T141823_20180112T141850_009139_0105AA_E6F5
+    output: asf_search
+    # use_maturity: True
+
+    expected file: geojson
+    expected code: 200
+
 - no output specified:
     reference: J1_08743_STD_F275
     # use_maturity: True

--- a/yml_tests/test_URLs.yml
+++ b/yml_tests/test_URLs.yml
@@ -448,6 +448,10 @@ tests:
     granule_list: S1B_S6_GRDH_1SDV_20190911T214309_20190911T214338_017995_021E10_5CCB
     output: geojson
 
+- granule_list single asf_search:
+    granule_list: S1B_S6_GRDH_1SDV_20190911T214309_20190911T214338_017995_021E10_5CCB
+    output: asf_search
+
     expected file: geojson
     expected code: 200
 
@@ -873,6 +877,22 @@ tests:
     expected file: jsonlite
     expected code: 200
 
+- maxResults 1 asf_search:
+    platform: SENTINEL-1
+    maxResults: 1
+    output: asf_search
+
+    expected file: geojson
+    expected code: 200
+
+- maxResults 2 asf_search:
+    platform: SENTINEL-1
+    maxResults: 2
+    output: asf_search
+
+    expected file: geojson
+    expected code: 200
+
 - offNadirAngle single:
     offNadirAngle: 21.5
     maxResults: 10
@@ -958,6 +978,23 @@ tests:
     instrument: Avnir-2
     maxResults: 2
     output: geojson
+
+    expected file: geojson
+    expected code: 200
+
+- output asf_search Sentinel:
+    platform: SB
+    maxResults: 2000
+    output: asf_search
+
+    expected file: geojson
+    expected code: 200
+
+- output asf_search Avnir:
+    platform: Alos
+    instrument: Avnir-2
+    maxResults: 2
+    output: asf_search
 
     expected file: geojson
     expected code: 200

--- a/yml_tests/test_URLs_expected_400.yml
+++ b/yml_tests/test_URLs_expected_400.yml
@@ -131,6 +131,13 @@ tests:
     expected file: error json
     expected code: 400
 
+- bbox incomplete asf_search invalid:
+    bbox: -150.2,65.0,-150.1,65.5,0
+    output: asf_search
+
+    expected file: error json
+    expected code: 400
+
 - beamMode empty string invalid:
     beamMode: ""
     output: csv
@@ -571,6 +578,30 @@ tests:
     platform: SENTINEL-1
     maxResults: +_
     output: geojson
+
+    expected file: error json
+    expected code: 400
+
+- maxResults 0 asf_search invalid:
+    platform: SENTINEL-1
+    maxResults: 0
+    output: asf_search
+
+    expected file: error json
+    expected code: 400
+
+- maxResults a asf_search invalid:
+    platform: SENTINEL-1
+    maxResults: a
+    output: asf_search
+
+    expected file: error json
+    expected code: 400
+
+- maxResults specchar asf_search invalid:
+    platform: SENTINEL-1
+    maxResults: +_
+    output: asf_search
 
     expected file: error json
     expected code: 400


### PR DESCRIPTION
Adds a new format based on geojson that exposes the fields needed for client side baseline calculation. This format is intended to be consumed specifically by the Python search module asf_search.

For Sentinel-1:
- State Vectors
   - Positions
   - Velocities
   - Ascending Node Time

For Pre-calculated datasets:
- Pre-calculated insarBaseline values

The new fields are available in the `asf_search` output baseline property
