### PR TITLE
asf_search output tweak

### DIFF
--- a/SearchAPI/CMR/Output/asf_search.py
+++ b/SearchAPI/CMR/Output/asf_search.py
@@ -95,10 +95,10 @@ class ASFSearchStreamArray(JSONStreamArray):
                 'startTime': p['startTime'],
                 'stopTime': p['stopTime'],
                 'url': p['downloadUrl'],
-                'baseline': p.pop('baseline', None),
                 'temporalBaseline': p.pop('temporalBaseline', None),
                 'perpendicularBaseline': p.pop('perpendicularBaseline', None)
-            }
+            },
+            'baseline': p.pop('baseline', None),
         }
 
         return result


### PR DESCRIPTION
Moves baseline field out of properties in asf_search output and into it's own adjacent field

```
{
   'type': 'Feature',
   'geometry': {},
   'properties': {},
   'baseline': {}
}
```