### PR TITLE
List Search maturity error fix on prod

### DIFF
--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -99,9 +99,9 @@ def parse_granule(granule, req_fields):
             else:
                 return (None, None)
 
-        result['sv_pos_pre'],  result['sv_t_pos_pre']  = parse_sv(get_val(attr_path('SV_POSITION_PRE')))
+        result['sv_pos_pre'], result['sv_t_pos_pre'] = parse_sv(get_val(attr_path('SV_POSITION_PRE')))
         result['sv_pos_post'], result['sv_t_pos_post'] = parse_sv(get_val(attr_path('SV_POSITION_POST')))
-        result['sv_vel_pre'],  result['sv_t_vel_pre']  = parse_sv(get_val(attr_path('SV_VELOCITY_PRE')))
+        result['sv_vel_pre'], result['sv_t_vel_pre'] = parse_sv(get_val(attr_path('SV_VELOCITY_PRE')))
         result['sv_vel_post'], result['sv_t_vel_post'] = parse_sv(get_val(attr_path('SV_VELOCITY_POST')))
         result['baseline'] = {
             'stateVectors': {

--- a/SearchAPI/SearchQuery.py
+++ b/SearchAPI/SearchQuery.py
@@ -52,7 +52,7 @@ class APISearchQuery:
         return True
 
     def check_has_search_params(self):
-        non_searchable_param = ['output', 'maxresults', 'pagesize']
+        non_searchable_param = ['output', 'maxresults', 'pagesize', 'maturity']
         searchables = [
             v for v in self.request.local_values if v not in non_searchable_param
         ]

--- a/yml_tests/test_url_manager.py
+++ b/yml_tests/test_url_manager.py
@@ -622,9 +622,11 @@ class test_URL_Manager():
                 # Sentinel-1A
                 elif platform in ["SENTINEL-1A", "SA"]:
                     json_dict["Platform"][i] = "Sentinel-1A"
+                    json_dict["Platform"].append("Sentinel-1 Interferogram (BETA)")
                 # Sentinel-1B
                 elif platform in ["SENTINEL-1B", "SB"]:
                     json_dict["Platform"][i] = "Sentinel-1B"
+                    json_dict["Platform"].append("Sentinel-1 Interferogram (BETA)")
                 # Sir-C
                 elif platform in ["SIR-C"]:
                     del json_dict["Platform"][i]


### PR DESCRIPTION
List Search no longer throws wrong error when attempting to set maturity on prod

Setting maturity while performing a product/granule search should now throw the following error
`Validation Error: Unsupported parameter: maturity`

instead of
`Validation Error: granule_list may not be used in conjunction with other search parameters`