### PR TITLE
Temporal baseline fix

### DIFF
--- a/SearchAPI/Baseline/Stack.py
+++ b/SearchAPI/Baseline/Stack.py
@@ -170,7 +170,7 @@ def calculate_temporal_baselines(reference, stack):
             product['temporalBaseline'] = 0
         else:
             start = dateparser.parse(product['startTime'])
-            product['temporalBaseline'] = (start - reference_start).days
+            product['temporalBaseline'] = (start.date() - reference_start.date()).days
     return stack
 
 def offset_perpendicular_baselines(reference, stack):


### PR DESCRIPTION
Removes time component causing discrepancy in temporal baseline calculation.
(Temporal baseline between two scenes would differ depending on which was used as the reference in certain cases)