### PR TITLE
Temporal Baseline Fix

### DIFF
--- a/SearchAPI/Baseline/Stack.py
+++ b/SearchAPI/Baseline/Stack.py
@@ -170,7 +170,7 @@ def calculate_temporal_baselines(reference, stack):
             product['temporalBaseline'] = 0
         else:
             start = dateparser.parse(product['startTime'])
-            product['temporalBaseline'] = (start - reference_start).days
+            product['temporalBaseline'] = (start.date() - reference_start.date()).days
     return stack
 
 def offset_perpendicular_baselines(reference, stack):


### PR DESCRIPTION
Drop datetime's time component from temporal baseline calculation (this caused off-by-one discrepancies in temporal values with pairs based on which scene was used as the reference)