### PR TITLE
Basic Sentinel-1 uses collections instead of platform

### DIFF
--- a/SearchAPI/CMR/Output/jsonlite.py
+++ b/SearchAPI/CMR/Output/jsonlite.py
@@ -80,6 +80,24 @@ class JSONLiteStreamArray(JSONStreamArray):
             pass
 
         try:
+            if p['downloadUrl'] is None:
+                p['downloadUrl'] = ''
+        except TypeError:
+            pass
+
+        try:
+            if p['granuleName'] is None:
+                p['granuleName'] = p['product_file_id']
+        except TypeError:
+            pass
+        
+        try:
+            if p['fileName'] is None:
+                p['fileName'] = p['product_file_id']
+        except TypeError:
+            pass
+
+        try:
             if p['groupID'] is None:
                 p['groupID'] = p['granuleName']
         except TypeError:

--- a/SearchAPI/CMR/Query.py
+++ b/SearchAPI/CMR/Query.py
@@ -114,7 +114,7 @@ def subquery_list_from(params):
         if chunk_type in params:
             params[chunk_type] = chunk_list(list(set(params[chunk_type])), 500) # distinct and split
 
-    list_param_names = ['platform'] # these parameters will dodge the subquery system
+    list_param_names = ['platform', 'collections'] # these parameters will dodge the subquery system
 
     for k, v in params.items():
         if k in list_param_names:

--- a/SearchAPI/CMR/Translate/collections_by_platform.py
+++ b/SearchAPI/CMR/Translate/collections_by_platform.py
@@ -1,0 +1,596 @@
+concept_ids_by_platform = {
+   "DC-8": [
+      {
+         "collection": "AIRSAR_ALONGTRACK_INTERFEROMETRY_JPG",
+         "concept-id": "C1213921626-ASF"
+      },
+      {
+         "collection": "AIRSAR_POLSAR_3_FREQ_POLARIMETRY",
+         "concept-id": "C1213921661-ASF"
+      },
+      {
+         "collection": "AIRSAR_POLSAR_SYNOPTIC_3_FREQ_POLARIMETRY",
+         "concept-id": "C1213928843-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_C-BAND_DEM_AND_STOKES",
+         "concept-id": "C1213927035-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_DEM",
+         "concept-id": "C179001730-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_DEM_C",
+         "concept-id": "C1213925022-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_DEM_L",
+         "concept-id": "C1213926419-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_DEM_P",
+         "concept-id": "C1213926777-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_L-BAND_STOKES",
+         "concept-id": "C1213927939-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_P-BAND_STOKES",
+         "concept-id": "C1213928209-ASF"
+      }
+   ],
+   "ALOS": [
+      {
+         "collection": "ALOS_AVNIR_OBS_ORI",
+         "concept-id": "C1808440897-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_KMZ",
+         "concept-id": "C1206156901-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_LEVEL1.0",
+         "concept-id": "C1206485320-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_LEVEL1.1",
+         "concept-id": "C1206485527-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_LEVEL1.5",
+         "concept-id": "C1206485940-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_LEVEL2.2",
+         "concept-id": "C2011599335-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_RTC_HIGH_RES",
+         "concept-id": "C1206487504-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_RTC_LOW_RES",
+         "concept-id": "C1206487217-ASF"
+      }
+   ],
+   "ERS-1": [
+      {
+         "collection": "ERS-1_LEVEL0",
+         "concept-id": "C1210197768-ASF"
+      },
+      {
+         "collection": "ERS-1_LEVEL1",
+         "concept-id": "C1211627521-ASF"
+      }
+   ],
+   "ERS-2": [
+      {
+         "collection": "ERS-2_LEVEL0",
+         "concept-id": "C1208794942-ASF"
+      },
+      {
+         "collection": "ERS-2_LEVEL1",
+         "concept-id": "C1209373626-ASF"
+      }
+   ],
+   "Sentinel-1A": [
+      {
+         "collection": "Global Sentinel-1 Burst ID Map",
+         "concept-id": "C2450786986-ASF"
+      }
+   ],
+   "Sentinel-1B": [
+      {
+         "collection": "Global Sentinel-1 Burst ID Map",
+         "concept-id": "C2450786986-ASF"
+      }
+   ],
+   "JERS-1": [
+      {
+         "collection": "JERS-1_LEVEL0",
+         "concept-id": "C1207933168-ASF"
+      },
+      {
+         "collection": "JERS-1_LEVEL1",
+         "concept-id": "C1208662092-ASF"
+      }
+   ],
+   "RADARSAT-1": [
+      {
+         "collection": "RADARSAT-1_LEVEL0",
+         "concept-id": "C1206897141-ASF"
+      },
+      {
+         "collection": "RADARSAT-1_LEVEL1",
+         "concept-id": "C1206936391-ASF"
+      }
+   ],
+   "SEASAT 1": [
+      {
+         "collection": "SEASAT_SAR_LEVEL1_GEOTIFF",
+         "concept-id": "C1206500826-ASF"
+      },
+      {
+         "collection": "SEASAT_SAR_LEVEL1_HDF5",
+         "concept-id": "C1206500991-ASF"
+      }
+   ],
+   "SENTINEL-1A": [
+      {
+         "collection": "Sentinel-1 Interferograms (BETA)",
+         "concept-id": "C1595422627-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Amplitude (BETA)",
+         "concept-id": "C1596065640-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Coherence (BETA)",
+         "concept-id": "C1596065639-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Connected Components (BETA)",
+         "concept-id": "C1596065641-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Unwrapped Phase (BETA)",
+         "concept-id": "C1595765183-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Unwrapped Interferogram and Coherence Map (BETA)",
+         "concept-id": "C1379535600-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_GRD_FULL_RES",
+         "concept-id": "C1214471197-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_GRD_HIGH_RES",
+         "concept-id": "C1214470533-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1214471521-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1214471960-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1214470576-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1214472336-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_METADATA_OCN",
+         "concept-id": "C1266376001-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_METADATA_RAW",
+         "concept-id": "C1214470532-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_METADATA_SLC",
+         "concept-id": "C1214470496-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_OCN",
+         "concept-id": "C1214472977-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_RAW",
+         "concept-id": "C1214470561-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_GRD_FULL_RES",
+         "concept-id": "C1214472978-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_GRD_HIGH_RES",
+         "concept-id": "C1214470682-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1214472994-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1214473165-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1214470732-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1214473170-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SLC",
+         "concept-id": "C1214470488-ASF"
+      }
+   ],
+   "SENTINEL-1B": [
+      {
+         "collection": "Sentinel-1 Interferograms (BETA)",
+         "concept-id": "C1595422627-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Amplitude (BETA)",
+         "concept-id": "C1596065640-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Coherence (BETA)",
+         "concept-id": "C1596065639-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Connected Components (BETA)",
+         "concept-id": "C1596065641-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Unwrapped Phase (BETA)",
+         "concept-id": "C1595765183-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Unwrapped Interferogram and Coherence Map (BETA)",
+         "concept-id": "C1379535600-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_GRD_FULL_RES",
+         "concept-id": "C1327985697-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_GRD_HIGH_RES",
+         "concept-id": "C1327985645-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1327985660-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1327985651-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1327985741-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1327985578-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_METADATA_OCN",
+         "concept-id": "C1327985646-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_METADATA_RAW",
+         "concept-id": "C1327985650-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_METADATA_SLC",
+         "concept-id": "C1327985617-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_OCN",
+         "concept-id": "C1327985579-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_RAW",
+         "concept-id": "C1327985647-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_GRD_FULL_RES",
+         "concept-id": "C1327985644-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_GRD_HIGH_RES",
+         "concept-id": "C1327985571-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1327985740-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1327985674-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1327985619-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1327985739-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SLC",
+         "concept-id": "C1327985661-ASF"
+      }
+   ],
+   "SMAP": [
+      {
+         "collection": "SMAP_L1A_RADAR_METADATA_V001",
+         "concept-id": "C1214473426-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_METADATA_V002",
+         "concept-id": "C1243119801-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_QA_V001",
+         "concept-id": "C1214473839-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_QA_V002",
+         "concept-id": "C1243133204-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_METADATA_V001",
+         "concept-id": "C1243141638-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_METADATA_V002",
+         "concept-id": "C1243162394-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_METADATA_V003",
+         "concept-id": "C1243122884-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_QA_V001",
+         "concept-id": "C1243168733-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_QA_V002",
+         "concept-id": "C1243168866-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_QA_V003",
+         "concept-id": "C1243124139-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_V001",
+         "concept-id": "C1243197402-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_V002",
+         "concept-id": "C1243215430-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_V003",
+         "concept-id": "C1243124754-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_V001",
+         "concept-id": "C1214473171-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_V002",
+         "concept-id": "C1243149604-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_METADATA_V001",
+         "concept-id": "C1214473550-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_METADATA_V002",
+         "concept-id": "C1243197502-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_METADATA_V003",
+         "concept-id": "C1243126328-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_QA_V001",
+         "concept-id": "C1214474243-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_QA_V002",
+         "concept-id": "C1243216659-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_QA_V003",
+         "concept-id": "C1243129847-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_V001",
+         "concept-id": "C1214473308-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_V002",
+         "concept-id": "C1243253631-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_V003",
+         "concept-id": "C1243133445-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_METADATA_V001",
+         "concept-id": "C1214473624-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_METADATA_V002",
+         "concept-id": "C1243228612-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_METADATA_V003",
+         "concept-id": "C1243136142-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_QA_V001",
+         "concept-id": "C1214474435-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_QA_V002",
+         "concept-id": "C1243255360-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_QA_V003",
+         "concept-id": "C1243140611-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_V001",
+         "concept-id": "C1214473367-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_V002",
+         "concept-id": "C1243268956-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_V003",
+         "concept-id": "C1243144528-ASF"
+      }
+   ],
+   "STS-59": [
+      {
+         "collection": "STS-59_BROWSE_GRD",
+         "concept-id": "C1661710578-ASF"
+      },
+      {
+         "collection": "STS-59_BROWSE_SLC",
+         "concept-id": "C1661710581-ASF"
+      },
+      {
+         "collection": "STS-59_GRD",
+         "concept-id": "C1661710583-ASF"
+      },
+      {
+         "collection": "STS-59_METADATA_GRD",
+         "concept-id": "C1661710586-ASF"
+      },
+      {
+         "collection": "STS-59_METADATA_SLC",
+         "concept-id": "C1661710588-ASF"
+      },
+      {
+         "collection": "STS-59_SLC",
+         "concept-id": "C1661710590-ASF"
+      }
+   ],
+   "STS-68": [
+      {
+         "collection": "STS-68_BROWSE_GRD",
+         "concept-id": "C1661710593-ASF"
+      },
+      {
+         "collection": "STS-68_BROWSE_SLC",
+         "concept-id": "C1661710596-ASF"
+      },
+      {
+         "collection": "STS-68_GRD",
+         "concept-id": "C1661710597-ASF"
+      },
+      {
+         "collection": "STS-68_METADATA_GRD",
+         "concept-id": "C1661710600-ASF"
+      },
+      {
+         "collection": "STS-68_METADATA_SLC",
+         "concept-id": "C1661710603-ASF"
+      },
+      {
+         "collection": "STS-68_SLC",
+         "concept-id": "C1661710604-ASF"
+      }
+   ],
+   "G-III": [
+      {
+         "collection": "UAVSAR_INSAR_AMPLITUDE",
+         "concept-id": "C1214335430-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_AMPLITUDE_GRD",
+         "concept-id": "C1214335471-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_DEM",
+         "concept-id": "C1214335903-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_INTERFEROGRAM",
+         "concept-id": "C1214336045-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_INTERFEROGRAM_GRD",
+         "concept-id": "C1214336154-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_KMZ",
+         "concept-id": "C1214336554-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_METADATA",
+         "concept-id": "C1214336717-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_DEM",
+         "concept-id": "C1214353593-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_INCIDENCE",
+         "concept-id": "C1214353754-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_KMZ",
+         "concept-id": "C1214353859-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_METADATA",
+         "concept-id": "C1214353986-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_ML_COMPLEX_GRD",
+         "concept-id": "C1214337770-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_ML_COMPLEX_GRD_3X3",
+         "concept-id": "C1214354144-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_ML_COMPLEX_GRD_5X5",
+         "concept-id": "C1214354235-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_ML_COMPLEX_SLANT",
+         "concept-id": "C1214343609-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_PAULI",
+         "concept-id": "C1214354031-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_SLOPE",
+         "concept-id": "C1214408428-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_STOKES",
+         "concept-id": "C1214419355-ASF"
+      }
+   ]
+}

--- a/SearchAPI/CMR/Translate/collections_by_platform.py
+++ b/SearchAPI/CMR/Translate/collections_by_platform.py
@@ -1,4 +1,4 @@
-concept_ids_by_platform = {
+collections_by_platform = {
    "DC-8": [
       {
          "collection": "AIRSAR_ALONGTRACK_INTERFEROMETRY_JPG",
@@ -591,6 +591,942 @@ concept_ids_by_platform = {
       {
          "collection": "UAVSAR_POLSAR_STOKES",
          "concept-id": "C1214419355-ASF"
+      }
+   ]
+}
+
+collections_by_platform_uat = {
+   "DC-8": [
+      {
+         "collection": "AIRSAR_ALONGTRACK_INTERFEROMETRY",
+         "concept-id": "C1208652494-ASF"
+      },
+      {
+         "collection": "AIRSAR_ALONGTRACK_INTERFEROMETRY_JPG",
+         "concept-id": "C1000000306-ASF"
+      },
+      {
+         "collection": "AIRSAR_POLSAR_3_FREQ_POLARIMETRY",
+         "concept-id": "C1205256880-ASF"
+      },
+      {
+         "collection": "AIRSAR_POLSAR_SYNOPTIC_3_FREQ_POLARIMETRY",
+         "concept-id": "C1208713702-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_C-BAND_DEM_AND_STOKES",
+         "concept-id": "C1208707768-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_DEM",
+         "concept-id": "C1208655639-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_DEM_C",
+         "concept-id": "C1208680681-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_DEM_L",
+         "concept-id": "C1208691361-ASF"
+      },
+      {
+         "collection": "AIRSAR_TOPSAR_DEM_P",
+         "concept-id": "C1208703384-ASF"
+      }
+   ],
+   "ALOS": [
+      {
+         "collection": "ALOS_AVNIR_OBS_ORI",
+         "concept-id": "C1233629671-ASF"
+      },
+      {
+         "collection": "ALOS_AVNIR_OBS_ORI_BROWSE",
+         "concept-id": "C1234712303-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_INSAR_METADATA",
+         "concept-id": "C1229740239-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_KMZ",
+         "concept-id": "C1207019609-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_LEVEL1.1",
+         "concept-id": "C1207710476-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_LEVEL1.5",
+         "concept-id": "C1205261223-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_LEVEL2.2",
+         "concept-id": "C1239927797-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_RTC_HIGH_RES",
+         "concept-id": "C1207181535-ASF"
+      },
+      {
+         "collection": "ALOS_PALSAR_RTC_LOW_RES",
+         "concept-id": "C1208013295-ASF"
+      }
+   ],
+   "ERS-1": [
+      {
+         "collection": "ERS-1_LEVEL0",
+         "concept-id": "C1205261222-ASF"
+      },
+      {
+         "collection": "ERS-1_LEVEL1",
+         "concept-id": "C1205302527-ASF"
+      }
+   ],
+   "ERS-2": [
+      {
+         "collection": "ERS-2_LEVEL0",
+         "concept-id": "C1207143701-ASF"
+      },
+      {
+         "collection": "ERS-2_LEVEL1",
+         "concept-id": "C1207144966-ASF"
+      }
+   ],
+   "Sentinel-1A": [
+      {
+         "collection": "Global Sentinel-1 Burst ID Map",
+         "concept-id": "C1245953394-ASF"
+      }
+   ],
+   "Sentinel-1B": [
+      {
+         "collection": "Global Sentinel-1 Burst ID Map",
+         "concept-id": "C1245953394-ASF"
+      }
+   ],
+   "JERS-1": [
+      {
+         "collection": "JERS-1_LEVEL0",
+         "concept-id": "C1207175327-ASF"
+      },
+      {
+         "collection": "JERS-1_LEVEL1",
+         "concept-id": "C1207177736-ASF"
+      }
+   ],
+   "RADARSAT-1": [
+      {
+         "collection": "RADARSAT-1_LEVEL1",
+         "concept-id": "C1205181982-ASF"
+      },
+      {
+         "collection": "RADARSAT-1_POLAR_YEAR_ANTARCTICA_LEVEL1",
+         "concept-id": "C1215670813-ASF"
+      },
+      {
+         "collection": "RADARSAT-1_POLAR_YEAR_GREENLAND_LEVEL0",
+         "concept-id": "C1215709884-ASF"
+      },
+      {
+         "collection": "RADARSAT-1_POLAR_YEAR_GREENLAND_LEVEL1",
+         "concept-id": "C1215709880-ASF"
+      },
+      {
+         "collection": "RADARSAT-1_POLAR_YEAR_KAMCHATKA_LEVEL1",
+         "concept-id": "C1215714443-ASF"
+      },
+      {
+         "collection": "RADARSAT-1_POLAR_YEAR_SEA_ICE_MIN_MAX_LEVEL1",
+         "concept-id": "C1215775284-ASF"
+      },
+      {
+         "collection": "RADARSAT-1_POLAR_YEAR_TOOLIK_LEVEL1",
+         "concept-id": "C1215614037-ASF"
+      }
+   ],
+   "SEASAT 1": [
+      {
+         "collection": "SEASAT_SAR_LEVEL1_GEOTIFF",
+         "concept-id": "C1206752770-ASF"
+      },
+      {
+         "collection": "SEASAT_SAR_LEVEL1_HDF5",
+         "concept-id": "C1206144699-ASF"
+      }
+   ],
+   "SENTINEL-1A": [
+      {
+         "collection": "Sentinel-1 Interferograms (BETA)",
+         "concept-id": "C1225776654-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Amplitude (BETA)",
+         "concept-id": "C1225776655-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Coherence (BETA)",
+         "concept-id": "C1225776657-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Connected Components (BETA)",
+         "concept-id": "C1225776658-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Unwrapped Phase (BETA)",
+         "concept-id": "C1225776659-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Unwrapped Interferogram and Coherence Map (BETA)",
+         "concept-id": "C1216473132-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_GRD_FULL_RES",
+         "concept-id": "C1212200781-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_GRD_HIGH_RES",
+         "concept-id": "C1212201032-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1212209035-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1212209075-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1212209226-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1212212493-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_METADATA_OCN",
+         "concept-id": "C1215704763-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_METADATA_RAW",
+         "concept-id": "C1208115009-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_METADATA_SLC",
+         "concept-id": "C1208117434-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_OCN",
+         "concept-id": "C1212212560-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_RAW",
+         "concept-id": "C1205264459-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_GRD_HIGH_RES",
+         "concept-id": "C1212158327-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1212158318-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1212158326-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1212233976-ASF"
+      },
+      {
+         "collection": "SENTINEL-1A_SLC",
+         "concept-id": "C1205428742-ASF"
+      }
+   ],
+   "SENTINEL-1B": [
+      {
+         "collection": "Sentinel-1 Interferograms (BETA)",
+         "concept-id": "C1225776654-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Amplitude (BETA)",
+         "concept-id": "C1225776655-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Coherence (BETA)",
+         "concept-id": "C1225776657-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Connected Components (BETA)",
+         "concept-id": "C1225776658-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Interferograms - Unwrapped Phase (BETA)",
+         "concept-id": "C1225776659-ASF"
+      },
+      {
+         "collection": "Sentinel-1 Unwrapped Interferogram and Coherence Map (BETA)",
+         "concept-id": "C1216473132-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_GRD_FULL_RES",
+         "concept-id": "C1216244597-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_GRD_HIGH_RES",
+         "concept-id": "C1216244589-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1216244594-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1216244596-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1216244601-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1216244591-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_METADATA_OCN",
+         "concept-id": "C1216244590-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_METADATA_RAW",
+         "concept-id": "C1216244595-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_METADATA_SLC",
+         "concept-id": "C1216244585-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_OCN",
+         "concept-id": "C1216244593-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_RAW",
+         "concept-id": "C1216244592-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_GRD_FULL_RES",
+         "concept-id": "C1216244588-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_GRD_HIGH_RES",
+         "concept-id": "C1216244586-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1216244600-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1216244599-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1216244587-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1216244598-ASF"
+      },
+      {
+         "collection": "SENTINEL-1B_SLC",
+         "concept-id": "C1216244348-ASF"
+      }
+   ],
+   "SMAP": [
+      {
+         "collection": "SMAP_L1A_RADAR_METADATA_V001",
+         "concept-id": "C1212243437-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_METADATA_V002",
+         "concept-id": "C1213096699-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_METADATA_V003",
+         "concept-id": "C1216074750-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_QA_V001",
+         "concept-id": "C1212249653-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_QA_V002",
+         "concept-id": "C1213101573-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_QA_V003",
+         "concept-id": "C1216074751-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_METADATA_V001",
+         "concept-id": "C1213136752-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_METADATA_V002",
+         "concept-id": "C1213136799-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_METADATA_V003",
+         "concept-id": "C1233103964-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_QA_V001",
+         "concept-id": "C1213136709-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_QA_V002",
+         "concept-id": "C1213136844-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_QA_V003",
+         "concept-id": "C1216074923-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_V002",
+         "concept-id": "C1213136240-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_RECEIVE_ONLY_V003",
+         "concept-id": "C1216074755-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_V001",
+         "concept-id": "C1212243761-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_V002",
+         "concept-id": "C1213091807-ASF"
+      },
+      {
+         "collection": "SMAP_L1A_RADAR_V003",
+         "concept-id": "C1216074922-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_METADATA_V001",
+         "concept-id": "C1212196951-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_METADATA_V002",
+         "concept-id": "C1213115690-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_METADATA_V003",
+         "concept-id": "C1216074758-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_QA_V001",
+         "concept-id": "C1212243666-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_QA_V002",
+         "concept-id": "C1213115896-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_QA_V003",
+         "concept-id": "C1216074761-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_V001",
+         "concept-id": "C1212249811-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_V002",
+         "concept-id": "C1213125007-ASF"
+      },
+      {
+         "collection": "SMAP_L1B_SIGMA_NAUGHT_LOW_RES_V003",
+         "concept-id": "C1216074919-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_METADATA_V001",
+         "concept-id": "C1212246173-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_METADATA_V002",
+         "concept-id": "C1213125156-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_METADATA_V003",
+         "concept-id": "C1216074764-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_QA_V001",
+         "concept-id": "C1212249773-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_QA_V002",
+         "concept-id": "C1213134486-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_QA_V003",
+         "concept-id": "C1233101609-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_V001",
+         "concept-id": "C1212250364-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_V002",
+         "concept-id": "C1213134622-ASF"
+      },
+      {
+         "collection": "SMAP_L1C_SIGMA_NAUGHT_HIGH_RES_V003",
+         "concept-id": "C1216074770-ASF"
+      }
+   ],
+   "STS-59": [
+      {
+         "collection": "STS-59_BROWSE_GRD",
+         "concept-id": "C1226557819-ASF"
+      },
+      {
+         "collection": "STS-59_BROWSE_SLC",
+         "concept-id": "C1226557809-ASF"
+      },
+      {
+         "collection": "STS-59_GRD",
+         "concept-id": "C1226557808-ASF"
+      },
+      {
+         "collection": "STS-59_METADATA_GRD",
+         "concept-id": "C1226557810-ASF"
+      },
+      {
+         "collection": "STS-59_METADATA_SLC",
+         "concept-id": "C1226557811-ASF"
+      },
+      {
+         "collection": "STS-59_SLC",
+         "concept-id": "C1226557812-ASF"
+      }
+   ],
+   "STS-68": [
+      {
+         "collection": "STS-68_BROWSE_GRD",
+         "concept-id": "C1226557813-ASF"
+      },
+      {
+         "collection": "STS-68_BROWSE_SLC",
+         "concept-id": "C1226557814-ASF"
+      },
+      {
+         "collection": "STS-68_GRD",
+         "concept-id": "C1226557815-ASF"
+      },
+      {
+         "collection": "STS-68_METADATA_GRD",
+         "concept-id": "C1226557816-ASF"
+      },
+      {
+         "collection": "STS-68_METADATA_SLC",
+         "concept-id": "C1226557817-ASF"
+      },
+      {
+         "collection": "STS-68_SLC",
+         "concept-id": "C1226557818-ASF"
+      }
+   ],
+   "G-III": [
+      {
+         "collection": "UAVSAR_INSAR_AMPLITUDE",
+         "concept-id": "C1206116665-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_AMPLITUDE_GRD",
+         "concept-id": "C1206132445-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_DEM",
+         "concept-id": "C1211962154-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_INTERFEROGRAM",
+         "concept-id": "C1212001698-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_INTERFEROGRAM_GRD",
+         "concept-id": "C1212005594-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_KMZ",
+         "concept-id": "C1212019993-ASF"
+      },
+      {
+         "collection": "UAVSAR_INSAR_METADATA",
+         "concept-id": "C1212030772-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_DEM",
+         "concept-id": "C1207638502-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_INCIDENCE",
+         "concept-id": "C1210025872-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_KMZ",
+         "concept-id": "C1210485039-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_METADATA",
+         "concept-id": "C1210487703-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_ML_COMPLEX_GRD",
+         "concept-id": "C1207188317-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_ML_COMPLEX_GRD_3X3",
+         "concept-id": "C1210546638-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_ML_COMPLEX_GRD_5X5",
+         "concept-id": "C1206122195-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_ML_COMPLEX_SLANT",
+         "concept-id": "C1209970710-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_PAULI",
+         "concept-id": "C1207038647-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_SLOPE",
+         "concept-id": "C1210599503-ASF"
+      },
+      {
+         "collection": "UAVSAR_POLSAR_STOKES",
+         "concept-id": "C1210599673-ASF"
+      }
+   ]
+}
+
+collections_by_platform_uat_asfdev = {
+   "ALOS-2": [
+      {
+         "collection": "ALOS_2_PALSAR_2_LEVEL1.1",
+         "concept-id": "C1240722690-ASFDEV"
+      },
+      {
+         "collection": "ALOS_2_PALSAR_2_LEVEL1.5",
+         "concept-id": "C1240722458-ASFDEV"
+      },
+      {
+         "collection": "ALOS_2_PALSAR_2_LEVEL2.1",
+         "concept-id": "C1240722650-ASFDEV"
+      },
+      {
+         "collection": "ALOS_2_PALSAR_2_LEVEL3.1",
+         "concept-id": "C1240722677-ASFDEV"
+      }
+   ],
+   "ALOS": [
+      {
+         "collection": "ALOS_AVNIR_OBS_ORI",
+         "concept-id": "C1234413224-ASFDEV"
+      },
+      {
+         "collection": "ALOS_PALSAR_LEVEL1.1",
+         "concept-id": "C1239611505-ASFDEV"
+      },
+      {
+         "collection": "ALOS_PALSAR_LEVEL2.2",
+         "concept-id": "C1238733834-ASFDEV"
+      }
+   ],
+   "Sentinel-1A": [
+      {
+         "collection": "Global Sentinel-1 Burst ID Map",
+         "concept-id": "C1244598379-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts",
+         "concept-id": "C1244552887-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV0",
+         "concept-id": "C1245510724-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV1",
+         "concept-id": "C1255835256-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV2",
+         "concept-id": "C1256024505-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV3",
+         "concept-id": "C1256104765-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV4",
+         "concept-id": "C1256105655-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV5",
+         "concept-id": "C1256362312-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV6",
+         "concept-id": "C1256362994-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 Single Look Complex (SLC) Bursts",
+         "concept-id": "C1245830954-ASFDEV"
+      }
+   ],
+   "Sentinel-1B": [
+      {
+         "collection": "Global Sentinel-1 Burst ID Map",
+         "concept-id": "C1244598379-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts",
+         "concept-id": "C1244552887-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV0",
+         "concept-id": "C1245510724-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV1",
+         "concept-id": "C1255835256-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV2",
+         "concept-id": "C1256024505-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV3",
+         "concept-id": "C1256104765-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV4",
+         "concept-id": "C1256105655-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV5",
+         "concept-id": "C1256362312-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 bursts DEV6",
+         "concept-id": "C1256362994-ASFDEV"
+      },
+      {
+         "collection": "Sentinel-1 Single Look Complex (SLC) Bursts",
+         "concept-id": "C1245830954-ASFDEV"
+      }
+   ],
+   "SENTINEL-1A": [
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_GRD_FULL_RES",
+         "concept-id": "C1234413228-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_GRD_HIGH_RES",
+         "concept-id": "C1234413229-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1234413230-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1234413231-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1234413232-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_DUAL_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1234413233-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_METADATA_OCN",
+         "concept-id": "C1234413234-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_METADATA_RAW",
+         "concept-id": "C1234413235-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_METADATA_SLC",
+         "concept-id": "C1234413236-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_OCN",
+         "concept-id": "C1234413237-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_RAW",
+         "concept-id": "C1234413238-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_GRD_FULL_RES",
+         "concept-id": "C1234413239-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_GRD_HIGH_RES",
+         "concept-id": "C1234413240-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1234413241-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1234413242-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1234413243-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_SINGLE_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1234413244-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1A_SLC",
+         "concept-id": "C1234413245-ASFDEV"
+      }
+   ],
+   "SENTINEL-1B": [
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_GRD_FULL_RES",
+         "concept-id": "C1234413246-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_GRD_HIGH_RES",
+         "concept-id": "C1234413247-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1234413248-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1234413249-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1234413250-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_DUAL_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1234413251-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_METADATA_OCN",
+         "concept-id": "C1234413252-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_METADATA_RAW",
+         "concept-id": "C1234413253-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_METADATA_SLC",
+         "concept-id": "C1234413254-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_OCN",
+         "concept-id": "C1234413255-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_RAW",
+         "concept-id": "C1234413256-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_GRD_FULL_RES",
+         "concept-id": "C1234413257-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_GRD_HIGH_RES",
+         "concept-id": "C1234413258-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_GRD_MEDIUM_RES",
+         "concept-id": "C1234413259-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_METADATA_GRD_FULL_RES",
+         "concept-id": "C1234413260-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_METADATA_GRD_HIGH_RES",
+         "concept-id": "C1234413261-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_SINGLE_POL_METADATA_GRD_MEDIUM_RES",
+         "concept-id": "C1234413262-ASFDEV"
+      },
+      {
+         "collection": "SENTINEL-1B_SLC",
+         "concept-id": "C1234413263-ASFDEV"
+      }
+   ],
+   "STS-59": [
+      {
+         "collection": "STS-59_BROWSE_GRD",
+         "concept-id": "C1234413264-ASFDEV"
+      },
+      {
+         "collection": "STS-59_BROWSE_SLC",
+         "concept-id": "C1234413265-ASFDEV"
+      },
+      {
+         "collection": "STS-59_GRD",
+         "concept-id": "C1234413266-ASFDEV"
+      },
+      {
+         "collection": "STS-59_METADATA_GRD",
+         "concept-id": "C1234413267-ASFDEV"
+      },
+      {
+         "collection": "STS-59_METADATA_SLC",
+         "concept-id": "C1234413268-ASFDEV"
+      },
+      {
+         "collection": "STS-59_SLC",
+         "concept-id": "C1234413269-ASFDEV"
+      }
+   ],
+   "STS-68": [
+      {
+         "collection": "STS-68_BROWSE_GRD",
+         "concept-id": "C1234413270-ASFDEV"
+      },
+      {
+         "collection": "STS-68_BROWSE_SLC",
+         "concept-id": "C1234413271-ASFDEV"
+      },
+      {
+         "collection": "STS-68_GRD",
+         "concept-id": "C1234413272-ASFDEV"
+      },
+      {
+         "collection": "STS-68_METADATA_GRD",
+         "concept-id": "C1234413273-ASFDEV"
+      },
+      {
+         "collection": "STS-68_METADATA_SLC",
+         "concept-id": "C1234413274-ASFDEV"
+      },
+      {
+         "collection": "STS-68_SLC",
+         "concept-id": "C1234413275-ASFDEV"
       }
    ]
 }

--- a/SearchAPI/CMR/Translate/input_fixer.py
+++ b/SearchAPI/CMR/Translate/input_fixer.py
@@ -105,7 +105,7 @@ def input_fixer(params, is_prod: bool = False, provider: str = "ASF"):
                 for a in platform_list
             ]))
             
-            if processing_level_unspecified:
+            if any_processing_level:
                 fixed_params['collections'] = collection_list
 
         elif k == 'beammode':

--- a/SearchAPI/CMR/Translate/input_fixer.py
+++ b/SearchAPI/CMR/Translate/input_fixer.py
@@ -4,9 +4,9 @@ import logging
 import requests
 
 from SearchAPI.asf_env import get_config
-from .collections_by_platform import concept_ids_by_platform
+from .collections_by_platform import collections_by_platform, collections_by_platform_uat, collections_by_platform_uat_asfdev
 
-def input_fixer(params, provider: str = "ASF"):
+def input_fixer(params, is_prod: bool = False, provider: str = "ASF"):
     """
     A few inputs need to be specially handled to make the flexible input the
     legacy API allowed match what's at CMR, since we can't use wildcards on
@@ -75,19 +75,28 @@ def input_fixer(params, provider: str = "ASF"):
             # exclude_concept_ids = ['C1214470532-ASF', 'C1214470561-ASF', 'C1327985650-ASF', 'C1327985647-ASF']
             # fixed_params['collections'] = exclude_concept_ids
             
-            processing_level_unspecified = 'processinglevel' not in params and provider == 'ASF'
+            any_processing_level = 'processinglevel' not in params 
+                       
+            if any_processing_level:
+                if is_prod:
+                    to_collections = collections_by_platform
+                elif provider == 'ASF':
+                    to_collections = collections_by_platform_uat
+                else:
+                    to_collections = collections_by_platform_uat_asfdev
+            
             for p in v:
                 if p.upper() in plat_aliases:
                     for x in plat_aliases[p.upper()]:
-                        if x in ['SENTINEL-1A', 'SENTINEL-1B'] and processing_level_unspecified:
-                            collection_list.extend([id_by_platform['concept-id'] for id_by_platform in concept_ids_by_platform[x]])
+                        if x in ['SENTINEL-1A', 'SENTINEL-1B'] and any_processing_level:
+                            collection_list.extend([id_by_platform['concept-id'] for id_by_platform in to_collections[x]])
                         else:
                             platform_list.append(x)
-                elif ((p.upper() in plat_names and p.upper() in ['SA', 'SB']) or p.upper() in ['SENTINEL-1A', 'SENTINEL-1B'])  and processing_level_unspecified:
+                elif ((p.upper() in plat_names and p.upper() in ['SA', 'SB']) or p.upper() in ['SENTINEL-1A', 'SENTINEL-1B'])  and any_processing_level:
                     if p.upper() in plat_names and p.upper() in ['SA', 'SB']:
-                        collection_list.extend([id_by_platform['concept-id'] for id_by_platform in concept_ids_by_platform[plat_names[p.upper()]]])
+                        collection_list.extend([id_by_platform['concept-id'] for id_by_platform in to_collections[plat_names[p.upper()]]])
                     else:
-                        collection_list.extend([id_by_platform['concept-id'] for id_by_platform in concept_ids_by_platform[p.upper()]])
+                        collection_list.extend([id_by_platform['concept-id'] for id_by_platform in to_collections[p.upper()]])
                 else:
                     platform_list.append(p)
             

--- a/SearchAPI/CMR/Translate/input_map.py
+++ b/SearchAPI/CMR/Translate/input_map.py
@@ -50,7 +50,8 @@ def input_map():
         'temporal':             ['temporal',                '{0}',                              None], # start/end end up here
         'groupid':              ['attribute[]',             'string,GROUP_ID,{0}',              parse_string_list],
         'insarstackid':         ['attribute[]',             'int,INSAR_STACK_ID,{0}',           parse_string],
-        'instrument':           ['instrument[]',            '{0}',                              parse_string]
-    }
+        'instrument':           ['instrument[]',            '{0}',                              parse_string],
+        'collections':          ['echo_collection_id[]',            '{0}',                              parse_string_list]
+    } #exclude[concept_id]
 
     return parameter_map

--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -79,7 +79,8 @@ def parse_granule(granule, req_fields):
         remove_field('browse')
 
     if 'fileName' in req_fields:
-        result['fileName'] = get_val("./OnlineAccessURLs/OnlineAccessURL/URL").split('/')[-1]
+        file_name = get_val("./OnlineAccessURLs/OnlineAccessURL/URL")
+        result['fileName'] = file_name.split('/')[-1] if file_name else None
         remove_field('fileName')
 
     if 'stateVectors' in req_fields or ('canInsar' in req_fields and result['platform'] not in ['ALOS', 'RADARSAT-1', 'JERS-1', 'ERS-1', 'ERS-2']):

--- a/SearchAPI/SearchQuery.py
+++ b/SearchAPI/SearchQuery.py
@@ -86,7 +86,7 @@ class APISearchQuery:
         self.cmr_params, self.output, self.max_results = \
             translate_params(self.request.local_values)
 
-        self.cmr_params = input_fixer(self.cmr_params)
+        self.cmr_params = input_fixer(self.cmr_params, self.request.cmr_provider if self.request.cmr_provider else 'ASF')
 
     def cmr_query(self):
         logging.debug(f'Handle query from {self.request.access_route[-1]}')

--- a/SearchAPI/SearchQuery.py
+++ b/SearchAPI/SearchQuery.py
@@ -86,7 +86,9 @@ class APISearchQuery:
         self.cmr_params, self.output, self.max_results = \
             translate_params(self.request.local_values)
 
-        self.cmr_params = input_fixer(self.cmr_params, self.request.cmr_provider if self.request.cmr_provider else 'ASF')
+        self.cmr_params = input_fixer(self.cmr_params, 
+                                      self.request.asf_config['cmr_base'] == 'https://cmr.earthdata.nasa.gov', 
+                                      getattr(self.request, 'cmr_provider', 'ASF'))
 
     def cmr_query(self):
         logging.debug(f'Handle query from {self.request.access_route[-1]}')


### PR DESCRIPTION
In anticipation of burst product collections being added to CMR prod
- Searching by platform uses Sentinel-1 collection concept ids behind the scenes when querying CMR instead of the platform name (defined in `collections_by_platform.py`)
- Specifying `processingLevel` will cause SearchAPI to fall back to original method, so all Sentinel-1 product types will still be searchable