### PR TITLE
Fix Burst URL and fileName

### DIFF
--- a/SearchAPI/CMR/Query.py
+++ b/SearchAPI/CMR/Query.py
@@ -109,7 +109,7 @@ def subquery_list_from(params):
     def chunk_list(source_list, n):
         return [source_list[i * n:(i + 1) * n] for i in range((len(source_list) + n - 1) // n)]
 
-    chunk_lists = ['granule_list', 'product_list', 'relativeburstid', 'absoluteburstid', 'fullburstid'] # these list parameters will be broken into chunks for subquerying
+    chunk_lists = ['granule_list', 'product_list'] # these list parameters will be broken into chunks for subquerying
     for chunk_type in chunk_lists:
         if chunk_type in params:
             params[chunk_type] = chunk_list(list(set(params[chunk_type])), 500) # distinct and split

--- a/SearchAPI/CMR/SubQuery.py
+++ b/SearchAPI/CMR/SubQuery.py
@@ -47,6 +47,10 @@ class CMRSubQuery:
             if p[0] in ['readable_granule_name[]', 'granule_ur[]']:
                 for g in p[1].split(','):
                     final.append((p[0], g))
+            elif 'BURST_ID' in str(p[1]):
+                prefix = ','.join(p[1].split(',')[:2]) + ','
+                for g in p[1].split(',')[2:]:
+                    final.append((p[0], prefix + g))
             else:
                 final.append(p)
         return final

--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -193,8 +193,9 @@ def parse_granule(granule, req_fields):
         result['granuleName'] = get_val(field_paths['product_file_id'])
         result['beamMode'] = get_val(attr_path('BEAM_MODE'))
         urls = get_all_vals('./OnlineResources/OnlineResource/URL')
-        result['fileName'] = urls[0].split('/')[-1] if len(urls) else None
-        result['downloadUrl'] = urls[0]
+        if len(urls):
+            result['fileName'] = urls[0].split('/')[-1]
+            result['downloadUrl'] = urls[0]
 
 
     return result

--- a/SearchAPI/CMR/Translate/parse_cmr_response.py
+++ b/SearchAPI/CMR/Translate/parse_cmr_response.py
@@ -192,6 +192,9 @@ def parse_granule(granule, req_fields):
     if get_val(field_paths['processingLevel']) == 'BURST':
         result['granuleName'] = get_val(field_paths['product_file_id'])
         result['beamMode'] = get_val(attr_path('BEAM_MODE'))
+        urls = get_all_vals('./OnlineResources/OnlineResource/URL')
+        result['fileName'] = urls[0].split('/')[-1] if len(urls) else None
+        result['downloadUrl'] = urls[0]
 
 
     return result


### PR DESCRIPTION
- Updates relevant granule xpath for burst product download url
- Fixes relative/absolute/full burst ID search param chunking, uses subquery for each ID, allowing searching with lists of IDs like asf-search