### PR TITLE
Baseline "count" Output No Longer Runs Entire Stack Calcuation

### DIFF
--- a/SearchAPI/Baseline/Stack.py
+++ b/SearchAPI/Baseline/Stack.py
@@ -48,8 +48,7 @@ def build_stack_params(reference, req_fields=None, product_type=None):
     
     return stack_params, req_fields
 
-def get_stack_params(reference, product_type=None, is_count=False
-):
+def get_stack_params(reference, product_type=None):
     params = {'granule_list': reference}
     if product_type is not None:
         params['processingLevel'] = product_type

--- a/SearchAPI/Baseline/Stack.py
+++ b/SearchAPI/Baseline/Stack.py
@@ -8,7 +8,7 @@ precalc_datasets = ['AL', 'R1', 'E1', 'E2', 'J1']
 def get_stack(reference, req_fields=None, product_type=None):
     warnings = None
 
-    stack_params, req_fields = build_stack_params(reference, req_fields, product_type)
+    stack_params, req_fields = build_stack_query(reference, req_fields, product_type)
 
     stack = query_stack(stack_params, req_fields)
 
@@ -26,7 +26,7 @@ def get_stack(reference, req_fields=None, product_type=None):
 
     return stack, warnings
 
-def build_stack_params(reference, req_fields=None, product_type=None):
+def build_stack_query(reference, req_fields=None, product_type=None):
     try:
         stack_params = get_stack_params(reference, product_type=product_type)
     except ValueError as e:

--- a/SearchAPI/Baseline/__init__.py
+++ b/SearchAPI/Baseline/__init__.py
@@ -1,3 +1,4 @@
 from .Stack import get_stack
 from .Stack import get_default_product_type
+from .Stack import build_stack_params
 from .Calc import calculate_perpendicular_baselines

--- a/SearchAPI/Baseline/__init__.py
+++ b/SearchAPI/Baseline/__init__.py
@@ -1,4 +1,4 @@
 from .Stack import get_stack
 from .Stack import get_default_product_type
-from .Stack import build_stack_params
+from .Stack import build_stack_query
 from .Calc import calculate_perpendicular_baselines

--- a/SearchAPI/StackQuery.py
+++ b/SearchAPI/StackQuery.py
@@ -9,7 +9,7 @@ from SearchAPI.CMR.Translate import input_fixer, translate_params
 import SearchAPI.api_headers as api_headers
 from SearchAPI.CMR.Input import parse_string
 from SearchAPI.CMR.Output import output_translators
-from SearchAPI.Baseline import get_stack, get_default_product_type, build_stack_params
+from SearchAPI.Baseline import get_stack, get_default_product_type, build_stack_query
 
 
 class APIStackQuery:
@@ -32,18 +32,14 @@ class APIStackQuery:
             is_count = self.params['output'].lower() == 'count'
 
             if is_count:
-                params, req_fields = build_stack_params(
+                params, req_fields = build_stack_query(
                     reference=self.params['reference'],
                     req_fields=req_fields,
                     product_type=self.params['processinglevel'])
 
                 params,_,_ = translate_params(params)
                 params = input_fixer(params)
-                stack = CMRQuery(
-                    req_fields,
-                    params=dict(params)
-                )
-                # stack = CMRQuery(req_fields, params=params)
+                stack = CMRQuery(req_fields, params=dict(params))
                 return make_response(f'{stack.get_count()}\n')
             else:
                 stack, warnings = get_stack(

--- a/SearchAPI/StackQuery.py
+++ b/SearchAPI/StackQuery.py
@@ -1,13 +1,15 @@
 import json
+from SearchAPI.CMR.Query import CMRQuery
 
 from flask import Response, make_response
 from datetime import datetime
 import logging
+from SearchAPI.CMR.Translate import input_fixer, translate_params
 
 import SearchAPI.api_headers as api_headers
 from SearchAPI.CMR.Input import parse_string
 from SearchAPI.CMR.Output import output_translators
-from SearchAPI.Baseline import get_stack, get_default_product_type
+from SearchAPI.Baseline import get_stack, get_default_product_type, build_stack_params
 
 
 class APIStackQuery:
@@ -28,12 +30,27 @@ class APIStackQuery:
             translator, mimetype, suffix, req_fields = translators.get(self.params['output'], translators['metalink'])
 
             is_count = self.params['output'].lower() == 'count'
-            stack, warnings = get_stack(
-                reference=self.params['reference'],
-                req_fields=req_fields,
-                product_type=self.params['processinglevel'])
+
             if is_count:
-                return make_response(f'{len(stack)}\n')
+                params, req_fields = build_stack_params(
+                    reference=self.params['reference'],
+                    req_fields=req_fields,
+                    product_type=self.params['processinglevel'])
+
+                params,_,_ = translate_params(params)
+                params = input_fixer(params)
+                stack = CMRQuery(
+                    req_fields,
+                    params=dict(params)
+                )
+                # stack = CMRQuery(req_fields, params=params)
+                return make_response(f'{stack.get_count()}\n')
+            else:
+                stack, warnings = get_stack(
+                    reference=self.params['reference'],
+                    req_fields=req_fields,
+                    product_type=self.params['processinglevel'])
+  
 
 
             filename = make_filename(suffix)


### PR DESCRIPTION
baseline endpoint no longer builds entire stack when using `output=count`