### PR TITLE
Subquery performance and status logging

### DIFF
--- a/SearchAPI/CMR/Query.py
+++ b/SearchAPI/CMR/Query.py
@@ -122,7 +122,7 @@ class CMRQuery:
                                     'Value': request.asf_base_maturity
                                 }
                             ],
-                            'Unit': 'Seconds',
+                            'Unit': 'None',
                             'Values': subquery_times
                         }
                     ],

--- a/SearchAPI/CMR/SubQuery.py
+++ b/SearchAPI/CMR/SubQuery.py
@@ -240,7 +240,7 @@ class CMRSubQuery:
                                     'Value': request.asf_base_maturity
                                 }
                             ],
-                            'Unit': 'Seconds',
+                            'Unit': 'None',
                             'Value': elapsed_time
                         }
                     ],

--- a/SearchAPI/CMR/SubQuery.py
+++ b/SearchAPI/CMR/SubQuery.py
@@ -225,7 +225,7 @@ class CMRSubQuery:
         logging.error(session.headers)
         logging.error(f'Error body: {response.text}')
 
-    def log_subquery_time(elapsed_time):
+    def log_subquery_time(self, elapsed_time):
         try:
             if request.asf_config['cloudwatch_metrics']:
                 logging.debug('Logging subquery run time to cloudwatch metrics')
@@ -240,7 +240,7 @@ class CMRSubQuery:
                                     'Value': request.asf_base_maturity
                                 }
                             ],
-                            'Unit': 'None',
+                            'Unit': 'Seconds',
                             'Value': elapsed_time
                         }
                     ],

--- a/SearchAPI/CMR/SubQuery.py
+++ b/SearchAPI/CMR/SubQuery.py
@@ -9,7 +9,7 @@ from flask import request
 from SearchAPI.asf_env import get_config
 from SearchAPI.CMR.Translate import parse_cmr_response
 from SearchAPI.CMR.Exceptions import CMRError
-
+import boto3
 
 class CMRSubQuery:
     def __init__(self, req_fields, params, extra_params):
@@ -169,6 +169,8 @@ class CMRSubQuery:
             if query_duration > 10:
                 self.log_slow_cmr_response(session, response, query_duration)
 
+            self.log_subquery_time(query_duration)
+            
             if response.status_code != 200:
                 self.log_bad_cmr_response(
                     attempt, max_retry, response, session
@@ -222,3 +224,27 @@ class CMRSubQuery:
         logging.error('Headers sent to CMR:')
         logging.error(session.headers)
         logging.error(f'Error body: {response.text}')
+
+    def log_subquery_time(elapsed_time):
+        try:
+            if request.asf_config['cloudwatch_metrics']:
+                logging.debug('Logging subquery run time to cloudwatch metrics')
+                cloudwatch = boto3.client('cloudwatch')
+                cloudwatch.put_metric_data(
+                    MetricData = [
+                        {
+                            'MetricName': 'SubqueryRuntime',
+                            'Dimensions': [
+                                {
+                                    'Name': 'maturity',
+                                    'Value': request.asf_base_maturity
+                                }
+                            ],
+                            'Unit': 'Seconds',
+                            'Value': elapsed_time
+                        }
+                    ],
+                    Namespace = 'SearchAPI'
+                )
+        except Exception as e:
+            logging.exception(f'Failure during subquery run time logging: {e}')


### PR DESCRIPTION
`get_page()` now reports every status code (200, 400, 500, etc) and the query duration to cloudfront metrics