### PR TITLE
`shortName`, `cmr_token` form data fallback

### DIFF
--- a/SearchAPI/CMR/Output/geojson.py
+++ b/SearchAPI/CMR/Output/geojson.py
@@ -58,13 +58,19 @@ class GeoJSONStreamArray(JSONStreamArray):
         except TypeError:
             pass
 
+        if p.get('absoluteOrbit') is not None and len(p.get('absoluteOrbit')):
+            p['absoluteOrbit'] = p['absoluteOrbit'][0]
+        
+        coordinates = []
+        
+        if p.get('shape') is not None:
+            coordinates = [[float(c['lon']), float(c['lat'])] for c in p.get('shape')]
+        
         result = {
             'type': 'Feature',
             'geometry': {
                 'type': 'Polygon',
-                'coordinates': [
-                    [[float(c['lon']), float(c['lat'])] for c in p['shape']]
-                ]
+                'coordinates': coordinates
             },
             'properties': {
                 'beamModeType': p['beamModeType'],
@@ -82,7 +88,7 @@ class GeoJSONStreamArray(JSONStreamArray):
                 'insarStackId': p['insarGrouping'],
                 'md5sum': p['md5sum'],
                 'offNadirAngle': p['offNadirAngle'],
-                'orbit': p['absoluteOrbit'][0],
+                'orbit': p['absoluteOrbit'],
                 'pathNumber': p['relativeOrbit'],
                 'platform': p['platform'],
                 'pointingAngle': p['pointingAngle'],

--- a/SearchAPI/CMR/Query.py
+++ b/SearchAPI/CMR/Query.py
@@ -114,7 +114,7 @@ def subquery_list_from(params):
         if chunk_type in params:
             params[chunk_type] = chunk_list(list(set(params[chunk_type])), 500) # distinct and split
 
-    list_param_names = ['platform', 'collections'] # these parameters will dodge the subquery system
+    list_param_names = ['platform', 'collections', 'shortname'] # these parameters will dodge the subquery system
 
     for k, v in params.items():
         if k in list_param_names:

--- a/SearchAPI/CMR/SubQuery.py
+++ b/SearchAPI/CMR/SubQuery.py
@@ -25,6 +25,9 @@ class CMRSubQuery:
         self.headers = {}
         
         token = request.args.get("cmr_token")
+        if token is None:
+            token = request.form.get('cmr_token')
+        
         if token != None:
             self.headers['Authorization'] = f'Bearer {token}'
 

--- a/SearchAPI/CMR/Translate/input_map.py
+++ b/SearchAPI/CMR/Translate/input_map.py
@@ -57,7 +57,8 @@ def input_map():
         'absoluteburstid':      ['attribute[]',             'int,BURST_ID_ABSOLUTE,{0}',        parse_int_list],
         'fullburstid':          ['attribute[]',             'string,BURST_ID_FULL,{0}',         parse_string_list],
         'operaburstid':         ['attribute[]',             'string,OPERA_BURST_ID,{0}',        parse_string_list],
-        'dataset':              [None,                      '{0}',                              parse_string_list]
+        'dataset':              [None,                      '{0}',                              parse_string_list],
+        'shortname':            ['shortName',                      '{0}',                       parse_string_list]
     }
 
     return parameter_map


### PR DESCRIPTION
- `shortName` now valid search keyword
- now checks form data for `cmr_token` when none found in args as fallback
- tweak geojson to support output without spatial data