### PR TITLE
Add support for alos-2 file types

### DIFF
--- a/SearchAPI/CMR/Translate/datasets.py
+++ b/SearchAPI/CMR/Translate/datasets.py
@@ -125,7 +125,7 @@ platform_datasets = {
         "C1257995186-ASF",
         "C1259974840-ASF",
         "C1271830354-ASF", # OPERA-DISP
-        "C3294057315-ASF"
+        "C3294057315-ASF",
     ],
     "OPERA-S1-CALVAL": [
         "C1260721945-ASF",  # CSLC

--- a/SearchAPI/CMR/Translate/datasets.py
+++ b/SearchAPI/CMR/Translate/datasets.py
@@ -125,6 +125,7 @@ platform_datasets = {
         "C1257995186-ASF",
         "C1259974840-ASF",
         "C1271830354-ASF", # OPERA-DISP
+        "C3294057315-ASF"
     ],
     "OPERA-S1-CALVAL": [
         "C1260721945-ASF",  # CSLC

--- a/SearchAPI/CMR/Translate/input_map.py
+++ b/SearchAPI/CMR/Translate/input_map.py
@@ -43,6 +43,7 @@ def input_map():
         'bbox':                 ['bounding_box',            '{0}',                              parse_bbox_string],
         'circle':               ['circle[]',                  '{0}',                            parse_circle_string],
         'processinglevel':      ['attribute[]',             'string,PROCESSING_TYPE,{0}',       parse_string_list],
+        'processingtype':      ['attribute[]',             'string,PROCESSING_LEVEL,{0}',       parse_string_list],
         'relativeorbit':        ['attribute[]',             'int,PATH_NUMBER,{0}',              parse_int_or_range_list],
         'processingdate':       ['updated_since',           '{0}',                              parse_date],
         'start':                [None,                      '{0}',                              parse_date],


### PR DESCRIPTION
 - Adds a new search parameter for searching with `processinglevel` instead of `processingtype`, it's a bit wonky since it seems like at some point the naming got switched around.
 - Adds the production OPERA_L3_DISP products collection